### PR TITLE
test: expand API auth and branch coverage across handlers

### DIFF
--- a/__mocks__/@aws-sdk/client-cloudwatch.ts
+++ b/__mocks__/@aws-sdk/client-cloudwatch.ts
@@ -4,4 +4,5 @@ export const CloudWatchClientMock = new BaseClientMock();
 
 export const CloudWatchClient = CloudWatchClientMock.client;
 export const PutMetricDataCommand = CloudWatchClientMock.getCommand('putMetricData');
+export const GetMetricDataCommand = CloudWatchClientMock.getCommand('getMetricData');
 export const ListTagsForResourceCommand = CloudWatchClientMock.getCommand('listTagsForResource');

--- a/src/resources/queue.ts
+++ b/src/resources/queue.ts
@@ -983,7 +983,7 @@ async function parseRecord(event: lambda.SQSRecord) {
       response = await handlePage(body);
       break;
     default:
-      throw new Error(`Unkown body - ${JSON.stringify(body)}`);
+      throw new Error(`Unknown body - ${JSON.stringify(body)}`);
   }
   return response;
 }

--- a/tests/resources/api/v2/aladtec.test.ts
+++ b/tests/resources/api/v2/aladtec.test.ts
@@ -1,0 +1,71 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import {
+  generateApiEvent, mockUserRequest
+} from './_utils';
+
+import { main } from '@/resources/api/v2/aladtec';
+import * as shiftDataMod from '@/utils/backend/shiftData';
+
+describe('resources/api/v2/aladtec', () => {
+  it('Returns 401 when user is missing', async () => {
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+    });
+
+    const res = await main(req);
+
+    expect(res).toEqual({
+      statusCode: 401,
+      body: JSON.stringify({
+        message: 'Missing Authentication Token',
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      multiValueHeaders: {},
+    });
+  });
+
+  it('Returns 403 for non-district admins', async () => {
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+    });
+    mockUserRequest(req, true, false, false);
+
+    const res = await main(req);
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('Returns shift people for district admins', async () => {
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+    });
+    mockUserRequest(req, true, true, true);
+    vi.spyOn(shiftDataMod, 'getShiftData').mockResolvedValue({
+      people: {
+        '1': 'User A',
+      },
+      shifts: [],
+    });
+
+    const res = await main(req);
+
+    expect(res).toEqual({
+      statusCode: 200,
+      body: JSON.stringify({
+        '1': 'User A',
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      multiValueHeaders: {},
+    });
+  });
+});

--- a/tests/resources/api/v2/department.test.ts
+++ b/tests/resources/api/v2/department.test.ts
@@ -1,0 +1,97 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import {
+  generateApiEvent, mockUserRequest, testUserAuth
+} from './_utils';
+
+import { main } from '@/resources/api/v2/department';
+import {
+  typedGet, typedUpdate
+} from '@/utils/backend/dynamoTyped';
+
+describe('resources/api/v2/department', () => {
+  describe('GET', () => {
+    testUserAuth({ method: 'GET', path: '', pathParameters: { id: 'Baca' } }, main, true);
+
+    it('Returns 403 when user lacks department access', async () => {
+      const req = generateApiEvent({
+        method: 'GET',
+        path: '',
+        pathParameters: {
+          id: 'Baca',
+        },
+      });
+      mockUserRequest(req, true, true, false);
+      (vi.mocked(typedGet) as any).mockResolvedValue({});
+
+      const res = await main(req);
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe('PATCH', () => {
+    testUserAuth({
+      method: 'PATCH',
+      path: '',
+      pathParameters: {
+        id: 'Baca',
+      },
+      body: JSON.stringify({
+        name: 'Updated Name',
+      }),
+    }, main, true);
+
+    it('Returns 400 for malformed request body', async () => {
+      const req = generateApiEvent({
+        method: 'PATCH',
+        path: '',
+        pathParameters: {
+          id: 'Baca',
+        },
+        body: JSON.stringify({
+          name: 10,
+        }),
+      });
+      mockUserRequest(req, true, true, true);
+
+      const res = await main(req);
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('Updates department fields', async () => {
+      const req = generateApiEvent({
+        method: 'PATCH',
+        path: '',
+        pathParameters: {
+          id: 'Baca',
+        },
+        body: JSON.stringify({
+          name: 'Updated Name',
+        }),
+      });
+      mockUserRequest(req, true, true, true);
+      (vi.mocked(typedGet) as any).mockResolvedValue({
+        Item: {
+          id: 'Baca',
+          name: 'Old Name',
+          pagingTalkgroups: [],
+          type: 'page',
+        },
+      });
+      (vi.mocked(typedUpdate) as any).mockResolvedValue({
+        Attributes: {
+          id: 'Baca',
+          name: 'Updated Name',
+          pagingTalkgroups: [],
+          type: 'page',
+        },
+      });
+
+      const res = await main(req);
+      expect(res.statusCode).toBe(200);
+      expect(typedUpdate).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/resources/api/v2/departments.test.ts
+++ b/tests/resources/api/v2/departments.test.ts
@@ -1,0 +1,139 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import {
+  generateApiEvent, mockUserRequest, testUserAuth
+} from './_utils';
+
+import { main } from '@/resources/api/v2/departments';
+import {
+  typedGet, typedPutItem, typedScan
+} from '@/utils/backend/dynamoTyped';
+
+describe('resources/api/v2/departments', () => {
+  testUserAuth({ method: 'GET', path: '' }, main, true);
+
+  it('Returns 403 for GET when admin has no department scope', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+    mockUserRequest(req, true, true, false);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('Returns sorted departments for admin', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+    mockUserRequest(req, true, true, true);
+    (vi.mocked(typedScan) as any).mockResolvedValue({
+      Items: [
+        { id: 'b', name: 'B', pagingTalkgroups: [], type: 'page' },
+        { id: 'a', name: 'A', pagingTalkgroups: [], type: 'page' },
+      ],
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('"id":"a"');
+  });
+
+  testUserAuth({
+    method: 'POST',
+    path: '',
+    body: JSON.stringify({
+      id: 'test',
+      name: 'Test',
+      pagingTalkgroups: [ 8198 ],
+      type: 'page',
+      invoiceFrequency: 'monthly',
+      invoiceEmail: [ 'billing@example.com' ],
+    }),
+  }, main, true);
+
+  it('Returns 403 for POST when user is not district admin', async () => {
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      body: JSON.stringify({
+        id: 'test',
+        name: 'Test',
+        pagingTalkgroups: [ 8198 ],
+        type: 'page',
+        invoiceFrequency: 'monthly',
+        invoiceEmail: [ 'billing@example.com' ],
+      }),
+    });
+    mockUserRequest(req, true, true, false);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('Returns 400 when create payload is incomplete', async () => {
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      body: JSON.stringify({
+        id: 'test',
+        name: 'Test',
+        pagingTalkgroups: [],
+        type: 'page',
+      }),
+    });
+    mockUserRequest(req, true, true, true);
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+    expect(typedGet).toHaveBeenCalledTimes(0);
+    expect(typedPutItem).toHaveBeenCalledTimes(0);
+  });
+
+  it('Returns 400 when department id already exists', async () => {
+    (vi.mocked(typedGet) as any).mockResolvedValue({
+      Item: {
+        id: 'test',
+        name: 'Existing',
+        type: 'page',
+      },
+    });
+
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      body: JSON.stringify({
+        id: 'test',
+        name: 'Test',
+        pagingTalkgroups: [ 8198 ],
+        type: 'page',
+        invoiceFrequency: 'monthly',
+        invoiceEmail: [ 'billing@example.com' ],
+      }),
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+    expect(typedPutItem).toHaveBeenCalledTimes(0);
+  });
+
+  it('Creates department for district admin', async () => {
+    (vi.mocked(typedGet) as any).mockResolvedValue({});
+
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      body: JSON.stringify({
+        id: 'test',
+        name: 'Test',
+        pagingTalkgroups: [ 8198 ],
+        type: 'page',
+        invoiceFrequency: 'monthly',
+        invoiceEmail: [ 'billing@example.com' ],
+      }),
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(typedPutItem).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/resources/api/v2/errors.test.ts
+++ b/tests/resources/api/v2/errors.test.ts
@@ -1,0 +1,86 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import {
+  generateApiEvent, mockUserRequest
+} from './_utils';
+
+import { main } from '@/resources/api/v2/errors';
+import {
+  typedPutItem,
+  typedScan
+} from '@/utils/backend/dynamoTyped';
+
+describe('resources/api/v2/errors', () => {
+  it('Returns 401 for GET with no user', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('Returns 403 for GET when not district admin', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+    mockUserRequest(req, true, true, false);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('Returns 200 with errors list for district admin GET', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+    mockUserRequest(req, true, true, true);
+    (vi.mocked(typedScan) as any).mockResolvedValue({
+      Items: [
+        {
+          Datetime: 1,
+          Url: '/x',
+          Message: 'msg',
+          Trace: 'trace',
+          UserAgent: 'ua',
+          User: 'u',
+        },
+      ],
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('"errors"');
+  });
+
+  it('Returns 400 when POST payload is malformed', async () => {
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      body: JSON.stringify({
+        url: '/test',
+      }),
+    });
+
+    const res = await main(req);
+
+    expect(res.statusCode).toBe(400);
+    expect(typedPutItem).toHaveBeenCalledTimes(0);
+  });
+
+  it('Stores incoming error payload and returns 500', async () => {
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      headers: {
+        'user-agent': 'vitest',
+      },
+      body: JSON.stringify({
+        url: '/test',
+        message: 'boom',
+        trace: 'stack',
+      }),
+    });
+
+    const res = await main(req);
+
+    expect(res.statusCode).toBe(500);
+    expect(typedPutItem).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/resources/api/v2/events.test.ts
+++ b/tests/resources/api/v2/events.test.ts
@@ -1,0 +1,207 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import {
+  AthenaClient
+} from '@aws-sdk/client-athena';
+import {
+  FirehoseClient
+} from '@aws-sdk/client-firehose';
+
+import {
+  generateApiEvent, mockUserRequest
+} from './_utils';
+
+import { main } from '@/resources/api/v2/events';
+
+describe('resources/api/v2/events', () => {
+  it('Returns 401 when user is missing on GET', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+    const res = await main(req);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('Returns 401 when user is inactive on GET', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+    mockUserRequest(req, false, false, false);
+    const res = await main(req);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('Returns 400 for malformed GET query', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('Starts an Athena query when groupBy is provided', async () => {
+    vi.spyOn(AthenaClient.prototype, 'send').mockResolvedValue({
+      QueryExecutionId: 'q1',
+    } as never);
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      multiValueQueryStringParameters: {
+        groupBy: [ 'event' ],
+      },
+    });
+    mockUserRequest(req, true, false, false);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('queryId');
+  });
+
+  it('Returns 500 when query execution state is FAILED', async () => {
+    vi.spyOn(AthenaClient.prototype, 'send').mockResolvedValue({
+      QueryExecution: {
+        Status: {
+          State: 'FAILED',
+        },
+      },
+    } as never);
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      multiValueQueryStringParameters: {
+        queryId: [ 'q1', ],
+      },
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it('Returns status while query execution is RUNNING', async () => {
+    vi.spyOn(AthenaClient.prototype, 'send').mockResolvedValue({
+      QueryExecution: {
+        Status: {
+          State: 'RUNNING',
+        },
+      },
+    } as never);
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      multiValueQueryStringParameters: {
+        queryId: [ 'q1', ],
+      },
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('RUNNING');
+  });
+
+  it('Parses paginated Athena query rows', async () => {
+    vi.spyOn(AthenaClient.prototype, 'send')
+      .mockResolvedValueOnce({
+        QueryExecution: {
+          Status: {
+            State: 'SUCCEEDED',
+          },
+        },
+      } as never)
+      .mockResolvedValueOnce({
+        ResultSet: {
+          Rows: [
+            { Data: [ { VarCharValue: 'event', }, { VarCharValue: 'num', }, ], },
+            { Data: [ { VarCharValue: 'call', }, { VarCharValue: '1', }, ], },
+          ],
+        },
+        NextToken: 'next-token',
+      } as never)
+      .mockResolvedValueOnce({
+        ResultSet: {
+          Rows: [
+            { Data: [ { VarCharValue: 'event', }, { VarCharValue: 'num', }, ], },
+            { Data: [ { VarCharValue: 'join', }, { VarCharValue: '2', }, ], },
+          ],
+        },
+      } as never);
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      multiValueQueryStringParameters: {
+        queryId: [ 'q1', ],
+      },
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('"count":2');
+    expect(res.body).toContain('"event":"call"');
+    expect(res.body).toContain('"event":"join"');
+  });
+
+  it('Returns 400 for invalid POST body', async () => {
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      body: JSON.stringify({ not: 'an-array' }),
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('Returns 400 when POST items fail validation', async () => {
+    vi.spyOn(FirehoseClient.prototype, 'send').mockResolvedValue({} as never);
+
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      body: JSON.stringify([
+        {
+          event: 'call',
+          talkgroup: '1234',
+          timestamp: Date.now(),
+        },
+      ]),
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('Sends valid POST items to firehose and still returns 400 when some items are invalid', async () => {
+    const firehoseSpy = vi.spyOn(FirehoseClient.prototype, 'send').mockResolvedValue({} as never);
+
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      queryStringParameters: {
+        code: process.env.API_CODE,
+      },
+      body: JSON.stringify([
+        {
+          tower: 'Saguache',
+          radioId: '1234',
+          event: 'call',
+          talkgroup: '8198',
+          talkgroupList: '8198',
+          timestamp: 1735689600000,
+        },
+        {
+          tower: 'Saguache',
+          event: 'call',
+        },
+      ]),
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+    expect(firehoseSpy).toHaveBeenCalledTimes(1);
+    expect(res.body).toContain('1-');
+  });
+});

--- a/tests/resources/api/v2/eventsList.test.ts
+++ b/tests/resources/api/v2/eventsList.test.ts
@@ -1,0 +1,165 @@
+import {
+  AthenaClient
+} from '@aws-sdk/client-athena';
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import { generateApiEvent } from './_utils';
+
+import { main } from '@/resources/api/v2/eventsList';
+import { typedQuery } from '@/utils/backend/dynamoTyped';
+
+describe('resources/api/v2/eventsList', () => {
+  it('Returns 404 for unsupported type', async () => {
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: {
+        type: 'bad',
+      },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('Returns 400 for invalid params', async () => {
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: {
+        type: 'talkgroup',
+      },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('Starts query and returns query id', async () => {
+    vi.spyOn(AthenaClient.prototype, 'send').mockResolvedValueOnce({ QueryExecutionId: 'q1' } as never);
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: {
+        type: 'talkgroup',
+        id: '8198',
+      },
+      queryStringParameters: {
+        endTime: Date.now().toString(),
+      },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('queryId');
+  });
+
+  it('Returns 500 when athena query id is missing', async () => {
+    vi.spyOn(AthenaClient.prototype, 'send').mockResolvedValueOnce({} as never);
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: {
+        type: 'talkgroup',
+        id: '8198',
+      },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it('Returns 500 when query state is CANCELLED', async () => {
+    vi.spyOn(AthenaClient.prototype, 'send').mockResolvedValueOnce({
+      QueryExecution: {
+        Status: {
+          State: 'CANCELLED',
+        },
+      },
+    } as never);
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: {
+        type: 'talkgroup',
+        id: '8198',
+      },
+      queryStringParameters: {
+        queryId: 'q1',
+      },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it('Returns in-progress status for queued query', async () => {
+    vi.spyOn(AthenaClient.prototype, 'send').mockResolvedValueOnce({
+      QueryExecution: {
+        Status: {
+          State: 'QUEUED',
+        },
+      },
+    } as never);
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: {
+        type: 'talkgroup',
+        id: '8198',
+      },
+      queryStringParameters: {
+        queryId: 'q1',
+      },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('QUEUED');
+  });
+
+  it('Returns merged events when query is complete', async () => {
+    vi.spyOn(AthenaClient.prototype, 'send')
+      .mockResolvedValueOnce({ QueryExecution: { Status: { State: 'SUCCEEDED' } } } as never)
+      .mockResolvedValueOnce({
+        ResultSet: {
+          Rows: [
+            { Data: [ { VarCharValue: 'event' }, { VarCharValue: 'timestamp' } ] },
+            { Data: [ { VarCharValue: 'tone' }, { VarCharValue: '1735689700000' } ] },
+          ],
+        },
+      } as never);
+    (vi.mocked(typedQuery) as any).mockResolvedValue({
+      Items: [
+        {
+          StartTime: 1735689700,
+          Added: 1735689701,
+          Talkgroup: 8198,
+          Key: 'audio/file.m4a',
+        },
+      ],
+    });
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: {
+        type: 'talkgroup',
+        id: '8198',
+      },
+      queryStringParameters: {
+        queryId: 'q1',
+      },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('events');
+  });
+});

--- a/tests/resources/api/v2/file.test.ts
+++ b/tests/resources/api/v2/file.test.ts
@@ -1,0 +1,51 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import { generateApiEvent } from './_utils';
+
+import { main } from '@/resources/api/v2/file';
+import { typedGet } from '@/utils/backend/dynamoTyped';
+
+describe('resources/api/v2/file', () => {
+  it('Returns 400 when id is missing', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('Returns 400 when id format is invalid', async () => {
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: {
+        id: 'abc',
+      },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('Returns file when found', async () => {
+    (vi.mocked(typedGet) as any).mockResolvedValue({
+      Item: {
+        Talkgroup: 8332,
+        Added: 1745367697,
+        Key: 'audio/test.m4a',
+      },
+    });
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: {
+        id: '8332-1745367697',
+      },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('audio/test.m4a');
+  });
+});

--- a/tests/resources/api/v2/files.test.ts
+++ b/tests/resources/api/v2/files.test.ts
@@ -1,0 +1,80 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import { generateApiEvent } from './_utils';
+
+import { main } from '@/resources/api/v2/files';
+import { mergeDynamoQueriesDocClient } from '@/resources/api/v2/_utils';
+
+describe('resources/api/v2/files', () => {
+  it('Returns 200 for default query', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('Returns 400 for invalid query input', async () => {
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      multiValueQueryStringParameters: {
+        before: [ 'nope' ],
+      },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('Builds talkgroup query with after filter', async () => {
+    vi.mocked(mergeDynamoQueriesDocClient).mockResolvedValue({
+      MinSortKey: 10,
+      MaxSortKey: 20,
+      MaxAfterKey: 30,
+      Items: [
+        {
+          Talkgroup: 8198,
+          StartTime: 20,
+          Added: 30,
+        },
+      ],
+    });
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      multiValueQueryStringParameters: {
+        tg: [ '8198' ],
+        after: [ '10' ],
+      },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(vi.mocked(mergeDynamoQueriesDocClient).mock.calls[0][0].ScanIndexForward).toBe(true);
+  });
+
+  it('Uses device table for radioId query and supports afterAdded', async () => {
+    vi.mocked(mergeDynamoQueriesDocClient).mockResolvedValue({
+      MinSortKey: null,
+      MaxSortKey: null,
+      MaxAfterKey: null,
+      Items: [],
+    });
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      multiValueQueryStringParameters: {
+        radioId: [ '1001' ],
+        afterAdded: [ '20' ],
+      },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('"files":[]');
+  });
+});

--- a/tests/resources/api/v2/heartbeats.test.ts
+++ b/tests/resources/api/v2/heartbeats.test.ts
@@ -2,7 +2,10 @@ import {
   describe, expect, it, vi
 } from 'vitest';
 
-import { PutMetricDataCommand } from '../../../../__mocks__/@aws-sdk/client-cloudwatch';
+import {
+  CloudWatchClientMock,
+  PutMetricDataCommand
+} from '../../../../__mocks__/@aws-sdk/client-cloudwatch';
 import {
   DynamoDBDocumentClientMock,
   ScanCommand, UpdateCommand
@@ -199,6 +202,39 @@ describe('resources/api/v2/heartbeats', () => {
           'Content-Type': 'application/json',
         },
       });
+    });
+
+    it('Returns 400 when code value does not match API_CODE', async () => {
+      const req = generateApiEvent({
+        method: 'POST',
+        path: '',
+        body: JSON.stringify({
+          code: 'WRONG_CODE',
+          Server: 'test',
+          IsPrimary: true,
+          IsActive: true,
+        }),
+      });
+
+      const res = await main(req);
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('Throws when CloudWatch metric submission fails', async () => {
+      CloudWatchClientMock.send.mockRejectedValueOnce(new Error('cloudwatch down'));
+
+      const req = generateApiEvent({
+        method: 'POST',
+        path: '',
+        body: JSON.stringify({
+          code: process.env.API_CODE,
+          Server: 'test',
+          IsPrimary: true,
+          IsActive: true,
+        }),
+      });
+
+      await expect(main(req)).rejects.toThrow('cloudwatch down');
     });
   });
 

--- a/tests/resources/api/v2/invoice.test.ts
+++ b/tests/resources/api/v2/invoice.test.ts
@@ -111,6 +111,42 @@ describe('resources/api/v2/invoice', () => {
   });
 
   describe('PATCH', () => {
+    testUserAuth({
+      method: 'PATCH',
+      path: '',
+      pathParameters: {
+        id: 'inv-001',
+      },
+      body: JSON.stringify({
+        paidDate: '2026-05-01',
+      }),
+    }, main, true);
+
+    it('Returns 403 for PATCH when user is not district admin', async () => {
+      const req = generateApiEvent({
+        method: 'PATCH',
+        path: '',
+        pathParameters: {
+          id: 'inv-001',
+        },
+        body: JSON.stringify({
+          paidDate: '2026-05-01',
+        }),
+      });
+      mockUserRequest(req, true, true, false);
+
+      expect(await main(req)).toEqual({
+        statusCode: 403,
+        body: JSON.stringify({
+          message: 'Missing Authentication Token',
+        }),
+        multiValueHeaders: {},
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+    });
+
     it('Returns 400 for future paidDate values', async () => {
       const req = generateApiEvent({
         method: 'PATCH',

--- a/tests/resources/api/v2/invoiceItems.test.ts
+++ b/tests/resources/api/v2/invoiceItems.test.ts
@@ -1,0 +1,148 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import {
+  generateApiEvent, mockUserRequest
+} from './_utils';
+
+import { main } from '@/resources/api/v2/invoiceItems';
+import { getTwilioSecret } from '@/deprecated/utils/general';
+import { typedGet } from '@/utils/backend/dynamoTyped';
+import { getTwilioItems } from '@/utils/backend/twilio';
+
+vi.mock('@/utils/backend/twilio', () => ({
+  getTwilioItems: vi.fn(),
+}));
+
+describe('resources/api/v2/invoiceItems', () => {
+  it('Returns 401 without user', async () => {
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: { id: '2026-JAN-BACA' },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('Returns 403 for non-admin user', async () => {
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: { id: '2026-JAN-BACA' },
+    });
+    mockUserRequest(req, true, false, false);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('Returns 404 when invoice is missing', async () => {
+    (vi.mocked(typedGet) as any).mockResolvedValue({});
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: { id: '2026-JAN-BACA' },
+      queryStringParameters: { month: 'last' },
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('Returns 403 for invoice with inaccessible department', async () => {
+    (vi.mocked(typedGet) as any).mockResolvedValue({
+      Item: {
+        id: '2026-JAN-BACA',
+        department: 'UnknownDepartment',
+      },
+    });
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: { id: '2026-JAN-BACA' },
+      queryStringParameters: { month: 'last' },
+    });
+    mockUserRequest(req, true, true, false);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('Returns twilio invoice items for authorized user', async () => {
+    (vi.mocked(typedGet) as any).mockResolvedValue({
+      Item: {
+        id: '2026-JAN-BACA',
+        department: 'Baca',
+      },
+    });
+    (vi.mocked(getTwilioItems) as any).mockResolvedValue([
+      {
+        type: 'twilio',
+        cat: 'Outbound SMS',
+        usage: 10,
+        usageUnit: 'messages',
+        price: 1.2,
+        start: '2026-01-01',
+        end: '2026-01-31',
+      },
+    ]);
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: { id: '2026-JAN-BACA' },
+      queryStringParameters: { month: 'last' },
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('"items"');
+  });
+
+  it('Throws when twilio secret is missing department credentials', async () => {
+    (vi.mocked(typedGet) as any).mockResolvedValue({
+      Item: {
+        id: '2026-JAN-BACA',
+        department: 'Baca',
+      },
+    });
+    (vi.mocked(getTwilioSecret) as any).mockResolvedValue({});
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: { id: '2026-JAN-BACA' },
+      queryStringParameters: { month: 'last' },
+    });
+    mockUserRequest(req, true, true, true);
+
+    await expect(main(req)).rejects.toThrow('Unable to find auth for account Baca');
+  });
+
+  it('Throws when twilio usage retrieval fails', async () => {
+    (vi.mocked(typedGet) as any).mockResolvedValue({
+      Item: {
+        id: '2026-JAN-BACA',
+        department: 'Baca',
+      },
+    });
+    (vi.mocked(getTwilioItems) as any).mockRejectedValue(new Error('twilio timeout'));
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: { id: '2026-JAN-BACA' },
+      queryStringParameters: { month: 'last' },
+    });
+    mockUserRequest(req, true, true, true);
+
+    await expect(main(req)).rejects.toThrow('twilio timeout');
+  });
+});

--- a/tests/resources/api/v2/login.test.ts
+++ b/tests/resources/api/v2/login.test.ts
@@ -1,0 +1,257 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import {
+  SecretsManagerClientMock
+} from '../../../../__mocks__/@aws-sdk/client-secrets-manager';
+
+import { generateApiEvent } from './_utils';
+
+import { main } from '@/resources/api/v2/login';
+import {
+  typedGet, typedUpdate
+} from '@/utils/backend/dynamoTyped';
+import { verify } from 'jsonwebtoken';
+
+vi.mock('jsonwebtoken', () => ({
+  sign: vi.fn(() => 'jwt-token'),
+  verify: vi.fn(),
+}));
+
+describe('resources/api/v2/login', () => {
+  describe('GET', () => {
+    it('Returns 400 for invalid id', async () => {
+      const req = generateApiEvent({
+        method: 'GET',
+        path: '',
+      });
+
+      const res = await main(req);
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('Returns 400 when user is already authenticated', async () => {
+      SecretsManagerClientMock.setResult('getSecretValue', {
+        SecretString: 'my-secret',
+      });
+      vi.mocked(verify).mockReturnValue({
+        phone: 5555555555,
+      } as never);
+      (vi.mocked(typedGet) as any).mockResolvedValue({
+        Item: {
+          phone: 5555555555,
+          fName: 'Auth',
+          lName: 'User',
+          departments: [ { id: 'Baca', active: true }, ],
+        },
+      });
+
+      const req = generateApiEvent({
+        method: 'GET',
+        path: '',
+        withUser: true,
+        pathParameters: {
+          id: '5555551111',
+        },
+      });
+
+      const res = await main(req);
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('Returns 200 for unknown user without revealing validity', async () => {
+      (vi.mocked(typedGet) as any).mockResolvedValue({});
+
+      const req = generateApiEvent({
+        method: 'GET',
+        path: '',
+        pathParameters: {
+          id: '5555551111',
+        },
+      });
+
+      const res = await main(req);
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('Queues auth code for valid user', async () => {
+      (vi.mocked(typedGet) as any).mockResolvedValue({
+        Item: {
+          phone: 5555551111,
+          fName: 'A',
+          lName: 'B',
+          departments: [ { id: 'Baca', active: true } ],
+        },
+      });
+
+      const req = generateApiEvent({
+        method: 'GET',
+        path: '',
+        pathParameters: {
+          id: '5555551111',
+        },
+      });
+
+      const res = await main(req);
+      expect(res.statusCode).toBe(200);
+    });
+  });
+
+  describe('POST', () => {
+    it('Returns 400 for bad code', async () => {
+      (vi.mocked(typedGet) as any).mockResolvedValue({
+        Item: {
+          phone: 5555551111,
+          fName: 'A',
+          lName: 'B',
+          departments: [ { id: 'Baca', active: true } ],
+          code: '123456',
+          codeExpiry: Date.now() - 10,
+        },
+      });
+      const req = generateApiEvent({
+        method: 'POST',
+        path: '',
+        pathParameters: {
+          id: '5555551111',
+        },
+        body: JSON.stringify({
+          code: '123456',
+        }),
+      });
+
+      const res = await main(req);
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('Returns 400 when code format is invalid', async () => {
+      const req = generateApiEvent({
+        method: 'POST',
+        path: '',
+        pathParameters: {
+          id: '5555551111',
+        },
+        body: JSON.stringify({
+          code: 'ABCDEF',
+        }),
+      });
+
+      const res = await main(req);
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('Returns 400 when user is already authenticated', async () => {
+      SecretsManagerClientMock.setResult('getSecretValue', {
+        SecretString: 'my-secret',
+      });
+      vi.mocked(verify).mockReturnValue({
+        phone: 5555555555,
+      } as never);
+      (vi.mocked(typedGet) as any).mockResolvedValue({
+        Item: {
+          phone: 5555555555,
+          fName: 'Auth',
+          lName: 'User',
+          departments: [ { id: 'Baca', active: true }, ],
+        },
+      });
+
+      const req = generateApiEvent({
+        method: 'POST',
+        path: '',
+        withUser: true,
+        pathParameters: {
+          id: '5555551111',
+        },
+        body: JSON.stringify({
+          code: '123456',
+        }),
+      });
+
+      const res = await main(req);
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('Returns 400 when login user is missing', async () => {
+      (vi.mocked(typedGet) as any).mockResolvedValue({});
+
+      const req = generateApiEvent({
+        method: 'POST',
+        path: '',
+        pathParameters: {
+          id: '5555551111',
+        },
+        body: JSON.stringify({
+          code: '123456',
+        }),
+      });
+
+      const res = await main(req);
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toContain('code');
+    });
+
+    it('Returns 400 when submitted code does not match user code', async () => {
+      (vi.mocked(typedGet) as any).mockResolvedValue({
+        Item: {
+          phone: 5555551111,
+          fName: 'A',
+          lName: 'B',
+          departments: [ { id: 'Baca', active: true } ],
+          code: '654321',
+          codeExpiry: Date.now() + 60000,
+        },
+      });
+
+      const req = generateApiEvent({
+        method: 'POST',
+        path: '',
+        pathParameters: {
+          id: '5555551111',
+        },
+        body: JSON.stringify({
+          code: '123456',
+        }),
+      });
+
+      const res = await main(req);
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toContain('code');
+    });
+
+    it('Returns 200 and sets cookies for valid code', async () => {
+      SecretsManagerClientMock.setResult('getSecretValue', {
+        SecretString: 'my-secret',
+      });
+      (vi.mocked(typedGet) as any).mockResolvedValue({
+        Item: {
+          phone: 5555551111,
+          fName: 'A',
+          lName: 'B',
+          departments: [ { id: 'Baca', active: true } ],
+          code: '123456',
+          codeExpiry: Date.now() + 60000,
+        },
+      });
+      (vi.mocked(typedUpdate) as any).mockResolvedValue({});
+
+      const req = generateApiEvent({
+        method: 'POST',
+        path: '',
+        pathParameters: {
+          id: '5555551111',
+        },
+        body: JSON.stringify({
+          code: '123456',
+        }),
+      });
+
+      const res = await main(req);
+      expect(res.statusCode).toBe(200);
+      expect(res.multiValueHeaders?.['Set-Cookie']?.length).toBe(2);
+      expect(res.multiValueHeaders?.['Set-Cookie']?.[0]).toContain('cofrn-user=5555551111');
+      expect(res.multiValueHeaders?.['Set-Cookie']?.[1]).toContain('cofrn-token=jwt-token');
+    });
+  });
+});

--- a/tests/resources/api/v2/logout.test.ts
+++ b/tests/resources/api/v2/logout.test.ts
@@ -1,0 +1,34 @@
+import {
+  describe, expect, it
+} from 'vitest';
+
+import { generateApiEvent } from './_utils';
+
+import { main } from '@/resources/api/v2/logout';
+
+describe('resources/api/v2/logout', () => {
+  it('Redirects to home when query is omitted', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(302);
+  });
+
+  it('Clears auth cookies and redirects', async () => {
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      headers: {
+        Cookie: 'cofrn-user=1;cofrn-token=t;other=x',
+      },
+      queryStringParameters: {
+        redirectTo: '/login',
+      },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(302);
+    expect(res.multiValueHeaders?.Location).toEqual([ '/login' ]);
+    expect((res.multiValueHeaders?.['Set-Cookie'] || []).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tests/resources/api/v2/metrics.test.ts
+++ b/tests/resources/api/v2/metrics.test.ts
@@ -1,0 +1,171 @@
+import {
+  CloudWatchClientMock
+} from '../../../../__mocks__/@aws-sdk/client-cloudwatch';
+import {
+  describe, expect, it
+} from 'vitest';
+
+import {
+  generateApiEvent, mockUserRequest
+} from './_utils';
+
+import { main } from '@/resources/api/v2/metrics';
+
+describe('resources/api/v2/metrics', () => {
+  it('Returns 401 for missing user', async () => {
+    const req = generateApiEvent({ method: 'POST', path: '' });
+    const res = await main(req);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('Returns 403 for non-admin user', async () => {
+    const req = generateApiEvent({ method: 'POST', path: '' });
+    mockUserRequest(req, true, false, false);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('Returns 400 for malformed body', async () => {
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      body: JSON.stringify({ metrics: 'bad' }),
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('Returns 400 when metrics payload fails validation', async () => {
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      body: JSON.stringify({
+        period: 3600,
+        startTime: 1735689600000,
+        endTime: 1735776000000,
+        metrics: [
+          {
+            type: 'count',
+            namespace: 'DTR Metrics',
+            metricName: 'Decode Rate',
+            label: 'Decode Rate',
+          },
+        ],
+      }),
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('Returns 400 when metrics list is empty', async () => {
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      body: JSON.stringify({
+        metrics: [],
+      }),
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toContain('metrics');
+  });
+
+  it('Returns 400 when lambda metric fn is unknown', async () => {
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      body: JSON.stringify({
+        metrics: [
+          {
+            type: 'lambda',
+            fn: 'missing_fn',
+            metric: 'Invocations',
+            stat: 'Sum',
+          },
+        ],
+      }),
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toContain('0-fn');
+  });
+
+  it('Returns 200 with empty labels/data for special lambda group with no configured functions', async () => {
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      body: JSON.stringify({
+        metrics: [
+          {
+            type: 'lambda',
+            fn: 'all',
+            metric: 'Invocations',
+            stat: 'Sum',
+          },
+        ],
+      }),
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('"labels":{}');
+    expect(res.body).toContain('"data":[]');
+  });
+
+  it('Returns metric data for valid count and timing metrics', async () => {
+    CloudWatchClientMock.setResult('getMetricData', {
+      MetricDataResults: [
+        {
+          Id: 'count_CVFD_API_Call',
+          Label: 'API Calls',
+          Timestamps: [ new Date('2026-01-01T00:00:00.000Z') ],
+          Values: [ 4 ],
+        },
+        {
+          Id: 'timing_Twilio_Health_PageDuration_p50',
+          Label: 'Page Duration',
+          Timestamps: [ new Date('2026-01-01T00:00:00.000Z') ],
+          Values: [ 2500 ],
+        },
+      ],
+    });
+
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      body: JSON.stringify({
+        metrics: [
+          {
+            type: 'count',
+            namespace: 'CVFD API',
+            metricName: 'Call',
+            label: 'API Calls',
+          },
+          {
+            type: 'timing',
+            namespace: 'Twilio Health',
+            metricName: 'PageDuration',
+            label: 'Page Duration',
+            stat: 'p50',
+          },
+        ],
+      }),
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('"labels"');
+    expect(res.body).toContain('"data"');
+  });
+});

--- a/tests/resources/api/v2/metricsAdd.test.ts
+++ b/tests/resources/api/v2/metricsAdd.test.ts
@@ -1,0 +1,59 @@
+import {
+  CloudWatchClientMock
+} from '../../../../__mocks__/@aws-sdk/client-cloudwatch';
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import { generateApiEvent } from './_utils';
+
+import { main } from '@/resources/api/v2/metricsAdd';
+
+describe('resources/api/v2/metricsAdd', () => {
+  it('Returns 401 when auth query code is missing', async () => {
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      body: JSON.stringify({ data: [] }),
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('Returns 400 when body data is empty', async () => {
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      queryStringParameters: {
+        code: process.env.API_CODE,
+      },
+      body: JSON.stringify({ data: [] }),
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('Publishes cloudwatch metrics and returns 200', async () => {
+    CloudWatchClientMock.setResult('putMetricData', {});
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      queryStringParameters: {
+        code: process.env.API_CODE,
+      },
+      body: JSON.stringify({
+        data: [
+          {
+            id: 'saguache',
+            val: 7,
+          },
+        ],
+      }),
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/tests/resources/api/v2/pages.test.ts
+++ b/tests/resources/api/v2/pages.test.ts
@@ -1,0 +1,60 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import {
+  generateApiEvent, mockUserRequest
+} from './_utils';
+
+import { main } from '@/resources/api/v2/pages';
+import { typedQuery } from '@/utils/backend/dynamoTyped';
+
+describe('resources/api/v2/pages', () => {
+  it('Returns 401 for missing user', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('Returns 401 for inactive user', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+    mockUserRequest(req, false, false, false);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('Allows empty query and returns 200', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('Returns paged files with before cursor', async () => {
+    (vi.mocked(typedQuery) as any).mockResolvedValue({
+      Items: [
+        {
+          Key: 'audio/test.m4a',
+          Talkgroup: 8198,
+          StartTime: 100,
+          Added: 101,
+        },
+      ],
+    });
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      multiValueQueryStringParameters: {
+        tg: [ '8198' ],
+      },
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('"before"');
+  });
+});

--- a/tests/resources/api/v2/radio.test.ts
+++ b/tests/resources/api/v2/radio.test.ts
@@ -1,0 +1,79 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import {
+  generateApiEvent, mockUserRequest
+} from './_utils';
+
+import { main } from '@/resources/api/v2/radio';
+import { typedUpdate } from '@/utils/backend/dynamoTyped';
+
+describe('resources/api/v2/radio', () => {
+  it('Returns 401 without user', async () => {
+    const req = generateApiEvent({
+      method: 'PATCH',
+      path: '',
+      pathParameters: {
+        id: '10',
+      },
+      body: JSON.stringify({
+        name: 'new',
+      }),
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('Returns 400 for malformed patch', async () => {
+    const req = generateApiEvent({
+      method: 'PATCH',
+      path: '',
+      pathParameters: {
+        id: '10',
+      },
+      body: JSON.stringify({
+        name: 123,
+      }),
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('Returns 403 when user cannot edit names', async () => {
+    const req = generateApiEvent({
+      method: 'PATCH',
+      path: '',
+      pathParameters: {
+        id: '10',
+      },
+      body: JSON.stringify({
+        name: 'new',
+      }),
+    });
+    mockUserRequest(req, true, true, false, false);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('Updates radio name', async () => {
+    (vi.mocked(typedUpdate) as any).mockResolvedValue({});
+    const req = generateApiEvent({
+      method: 'PATCH',
+      path: '',
+      pathParameters: {
+        id: '10',
+      },
+      body: JSON.stringify({
+        name: 'new-name',
+      }),
+    });
+    mockUserRequest(req, true, true, false, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/tests/resources/api/v2/radios.test.ts
+++ b/tests/resources/api/v2/radios.test.ts
@@ -1,0 +1,41 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import {
+  generateApiEvent, mockUserRequest
+} from './_utils';
+
+import { main } from '@/resources/api/v2/radios';
+import { typedFullScan } from '@/utils/backend/dynamoTyped';
+
+describe('resources/api/v2/radios', () => {
+  it('Returns 401 for missing user', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('Returns radios list for authenticated users', async () => {
+    (vi.mocked(typedFullScan) as any).mockResolvedValue({
+      Items: [
+        {
+          RadioID: '101',
+          Name: 'alpha',
+          Count: 1,
+          EventsCount: 1,
+        },
+      ],
+      LastEvaluatedKey: null,
+      Runs: 1,
+    });
+
+    const req = generateApiEvent({ method: 'GET', path: '' });
+    mockUserRequest(req, true, false, false);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('"count":1');
+  });
+});

--- a/tests/resources/api/v2/restart.test.ts
+++ b/tests/resources/api/v2/restart.test.ts
@@ -1,0 +1,48 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import { generateApiEvent } from './_utils';
+
+import { main } from '@/resources/api/v2/restart';
+import * as alarmStatusMod from '@/utils/backend/alarmStatus';
+import { sendAlertMessage } from '@/utils/backend/texts';
+
+describe('resources/api/v2/restart', () => {
+  it('Returns 400 for invalid tower param', async () => {
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: { tower: 'bad' },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('Returns 204 when restart is not needed', async () => {
+    vi.spyOn(alarmStatusMod, 'getCachedAlarmData').mockResolvedValue({});
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: { tower: 'PoolTable' },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(204);
+    expect(res.body).toBe('0');
+  });
+
+  it('Sends alert after restart acknowledgement', async () => {
+    vi.mocked(sendAlertMessage).mockResolvedValue();
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      pathParameters: { tower: 'PoolTable' },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(sendAlertMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/resources/api/v2/sites.test.ts
+++ b/tests/resources/api/v2/sites.test.ts
@@ -1,0 +1,120 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import {
+  generateApiEvent, mockUserRequest
+} from './_utils';
+
+import { main } from '@/resources/api/v2/sites';
+import { typedQuery } from '@/utils/backend/dynamoTyped';
+
+describe('resources/api/v2/sites', () => {
+  it('Returns 401 on GET without user', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+    const res = await main(req);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('Returns 403 on GET for non-admin', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+    mockUserRequest(req, true, false, false);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('Returns active sites for admins', async () => {
+    (vi.mocked(typedQuery) as any).mockResolvedValue({
+      Items: [
+        { SiteId: '1-2', IsActive: 'y' },
+      ],
+    });
+    const req = generateApiEvent({ method: 'GET', path: '' });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('"count":1');
+  });
+
+  it('Returns 400 for invalid adjacent payload shape', async () => {
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      body: JSON.stringify({
+        adjacent: [
+          [
+            {
+              rfss: '1',
+              site: '2',
+              sys_shortname: 'TEST',
+              time: '10',
+              conv_ch: '1',
+              site_failed: '0',
+              valid_info: '1',
+              composite_ctrl: '1',
+              active_conn: '1',
+              backup_ctrl: '0',
+              no_service_req: '0',
+              supports_data: '1',
+              supports_voice: '1',
+              supports_registration: '1',
+              supports_authentication: '1',
+            },
+          ],
+        ],
+      }),
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('Returns 400 for empty adjacent rows', async () => {
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      body: JSON.stringify({
+        adjacent: [ '' ],
+      }),
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('Returns 200 for valid adjacent payload', async () => {
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      body: JSON.stringify({
+        code: 'TEST_API_CODE',
+        adjacent: [
+          [
+            {
+              rfss: '1',
+              site: '2',
+              sys_shortname: 'TEST',
+              time: '10',
+              conv_ch: true,
+              site_failed: false,
+              valid_info: true,
+              composite_ctrl: true,
+              active_conn: true,
+              backup_ctrl: false,
+              no_service_req: false,
+              supports_data: true,
+              supports_voice: true,
+              supports_registration: true,
+              supports_authentication: true,
+            },
+          ],
+        ],
+      }),
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/tests/resources/api/v2/talkgroup.test.ts
+++ b/tests/resources/api/v2/talkgroup.test.ts
@@ -1,0 +1,81 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import {
+  generateApiEvent, mockUserRequest
+} from './_utils';
+
+import { main } from '@/resources/api/v2/talkgroup';
+import {
+  typedGet, typedUpdate
+} from '@/utils/backend/dynamoTyped';
+
+describe('resources/api/v2/talkgroup', () => {
+  it('Returns 400 for invalid params', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('Returns 404 when talkgroup is missing', async () => {
+    (vi.mocked(typedGet) as any).mockResolvedValue({});
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: { id: '8198' },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('Returns 401 for PATCH with no user', async () => {
+    const req = generateApiEvent({
+      method: 'PATCH',
+      path: '',
+      pathParameters: { id: '8198' },
+      body: JSON.stringify({ name: 'Dispatch' }),
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('Returns 403 for PATCH when cannot edit names', async () => {
+    const req = generateApiEvent({
+      method: 'PATCH',
+      path: '',
+      pathParameters: { id: '8198' },
+      body: JSON.stringify({ name: 'Dispatch' }),
+    });
+    mockUserRequest(req, true, true, true, false);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('Patches talkgroup name for editor', async () => {
+    (vi.mocked(typedGet) as any).mockResolvedValue({
+      Item: {
+        ID: 8198,
+      },
+    });
+    (vi.mocked(typedUpdate) as any).mockResolvedValue({
+      Attributes: {
+        ID: 8198,
+        Name: 'Dispatch',
+      },
+    });
+    const req = generateApiEvent({
+      method: 'PATCH',
+      path: '',
+      pathParameters: { id: '8198' },
+      body: JSON.stringify({ name: 'Dispatch' }),
+    });
+    mockUserRequest(req, true, false, false, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/tests/resources/api/v2/talkgroups.test.ts
+++ b/tests/resources/api/v2/talkgroups.test.ts
@@ -1,0 +1,51 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import { generateApiEvent } from './_utils';
+
+import { main } from '@/resources/api/v2/talkgroups';
+import {
+  typedFullQuery, typedFullScan
+} from '@/utils/backend/dynamoTyped';
+
+describe('resources/api/v2/talkgroups', () => {
+  it('Returns 200 for default query', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('Returns 400 when all=n is not accepted by validator', async () => {
+    (vi.mocked(typedFullQuery) as any).mockResolvedValue({
+      Items: [ { ID: 8198, Name: 'Dispatch' } ],
+      LastEvaluatedKey: null,
+      Runs: 1,
+    });
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      queryStringParameters: { all: 'n' },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('Returns all talkgroups when all=y', async () => {
+    (vi.mocked(typedFullScan) as any).mockResolvedValue({
+      Items: [ { ID: 1 }, { ID: 2 } ],
+      LastEvaluatedKey: null,
+      Runs: 1,
+    });
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      queryStringParameters: { all: 'y' },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('"count":2');
+  });
+});

--- a/tests/resources/api/v2/text.test.ts
+++ b/tests/resources/api/v2/text.test.ts
@@ -1,0 +1,43 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import { generateApiEvent } from './_utils';
+
+import { main } from '@/resources/api/v2/text';
+import { typedUpdate } from '@/utils/backend/dynamoTyped';
+
+describe('resources/api/v2/text', () => {
+  it('Returns 400 for invalid payload', async () => {
+    const req = generateApiEvent({
+      method: 'PATCH',
+      path: '',
+      body: JSON.stringify({
+        phone: 'bad',
+      }),
+      pathParameters: {
+        id: 'bad',
+      },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('Returns 200 when seen marker update succeeds', async () => {
+    (vi.mocked(typedUpdate) as any).mockResolvedValue({});
+    const req = generateApiEvent({
+      method: 'PATCH',
+      path: '',
+      pathParameters: {
+        id: '1735689600000',
+      },
+      body: JSON.stringify({
+        phone: 5555550000,
+      }),
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/tests/resources/api/v2/textlink.test.ts
+++ b/tests/resources/api/v2/textlink.test.ts
@@ -1,0 +1,35 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import { generateApiEvent } from './_utils';
+
+import { main } from '@/resources/api/v2/textlink';
+import { typedUpdate } from '@/utils/backend/dynamoTyped';
+
+describe('resources/api/v2/textlink', () => {
+  it('Returns 400 for invalid query', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('Returns redirect and marks message opened', async () => {
+    (vi.mocked(typedUpdate) as any).mockResolvedValue({});
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      queryStringParameters: {
+        f: '8332-123',
+        tg: '8198',
+        t: '1',
+        p: '5555551111',
+        m: '1735689600000',
+      },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(302);
+    expect(res.multiValueHeaders?.Location?.[0]).toContain('/?f=');
+  });
+});

--- a/tests/resources/api/v2/texts.test.ts
+++ b/tests/resources/api/v2/texts.test.ts
@@ -1,0 +1,142 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: vi.fn(async () => 'https://signed.example.com/textMedia/file-1'),
+}));
+
+
+import {
+  generateApiEvent, mockUserRequest
+} from './_utils';
+
+import { main } from '@/resources/api/v2/texts';
+import { typedQuery } from '@/utils/backend/dynamoTyped';
+
+describe('resources/api/v2/texts', () => {
+  it('Returns 401 without user', async () => {
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      queryStringParameters: { type: 'page' },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('Returns 400 when both type and department are missing', async () => {
+    const req = generateApiEvent({ method: 'GET', path: '' });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('Returns 403 for non-admins', async () => {
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      queryStringParameters: { type: 'page' },
+    });
+    mockUserRequest(req, true, false, false);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('Returns text list and replaces signed media urls', async () => {
+    (vi.mocked(typedQuery) as any).mockResolvedValue({
+      Items: [
+        {
+          datetime: 1,
+          type: 'page',
+          recipients: 1,
+          body: 'msg',
+          mediaUrls: [ 'textMedia/file-1', 'https://example.com/file-2' ],
+        },
+      ],
+      ScannedCount: 1,
+    });
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      queryStringParameters: { type: 'page' },
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('"texts"');
+    expect(res.body).toContain('https://signed.example.com/textMedia/file-1');
+    expect(res.body).toContain('https://example.com/file-2');
+  });
+
+  it('Filters account texts and zero-recipient texts when all is not set', async () => {
+    (vi.mocked(typedQuery) as any).mockResolvedValue({
+      Items: [
+        {
+          datetime: 1,
+          type: 'account',
+          recipients: 1,
+        },
+        {
+          datetime: 2,
+          type: 'department',
+          department: 'Baca',
+          recipients: 0,
+        },
+        {
+          datetime: 3,
+          type: 'department',
+          department: 'Baca',
+          recipients: 1,
+        },
+      ],
+      ScannedCount: 3,
+    });
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      queryStringParameters: { department: 'Baca' },
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('"count":1');
+    expect(res.body).toContain('"datetime":3');
+  });
+
+  it('Includes zero-recipient texts when all=y', async () => {
+    (vi.mocked(typedQuery) as any).mockResolvedValue({
+      Items: [
+        {
+          datetime: 2,
+          type: 'department',
+          department: 'Baca',
+          recipients: 0,
+        },
+      ],
+      ScannedCount: 1,
+    });
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      queryStringParameters: {
+        department: 'Baca',
+        all: 'y',
+      },
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('"count":1');
+    expect(res.body).toContain('"datetime":2');
+  });
+});

--- a/tests/resources/api/v2/user.test.ts
+++ b/tests/resources/api/v2/user.test.ts
@@ -1,0 +1,192 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import {
+  generateApiEvent, mockUserRequest
+} from './_utils';
+
+import { main } from '@/resources/api/v2/user';
+import {
+  typedDeleteItem,
+  typedGet,
+  typedUpdate
+} from '@/utils/backend/dynamoTyped';
+
+describe('resources/api/v2/user', () => {
+  it('Returns 401 on GET without user', async () => {
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: { id: '5555555555' },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('Returns frontend user object for current user GET', async () => {
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: { id: 'current' },
+    });
+    mockUserRequest(req, true, false, false);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('5555555555');
+  });
+
+  it('Returns 403 for non-admin GET of another user', async () => {
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: { id: '5555550001' },
+    });
+    mockUserRequest(req, true, false, false);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('Returns 404 for missing user on admin GET', async () => {
+    (vi.mocked(typedGet) as any).mockResolvedValue({});
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+      pathParameters: { id: '5555550001' },
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('Returns 400 when PATCH transcript settings conflict', async () => {
+    const req = generateApiEvent({
+      method: 'PATCH',
+      path: '',
+      pathParameters: { id: 'current' },
+      body: JSON.stringify({
+        getTranscript: true,
+        getTranscriptOnly: false,
+      }),
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('Returns 401 on PATCH without user', async () => {
+    const req = generateApiEvent({
+      method: 'PATCH',
+      path: '',
+      pathParameters: { id: 'current' },
+      body: JSON.stringify({
+        fName: 'New',
+      }),
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('Returns 403 on PATCH for non-admin editing another user', async () => {
+    const req = generateApiEvent({
+      method: 'PATCH',
+      path: '',
+      pathParameters: { id: '5555550001' },
+      body: JSON.stringify({
+        fName: 'New',
+      }),
+    });
+    mockUserRequest(req, true, false, false);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('Updates user when PATCH is valid', async () => {
+    (vi.mocked(typedGet) as any).mockResolvedValue({
+      Item: {
+        phone: 5555555555,
+        fName: 'Old',
+        lName: 'Name',
+        departments: [ { id: 'Baca', active: true } ],
+      },
+    });
+    (vi.mocked(typedUpdate) as any).mockResolvedValue({
+      Attributes: {
+        phone: 5555555555,
+        fName: 'New',
+        lName: 'Name',
+      },
+    });
+    const req = generateApiEvent({
+      method: 'PATCH',
+      path: '',
+      pathParameters: { id: '5555555555' },
+      body: JSON.stringify({
+        fName: 'New',
+      }),
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('Deletes user when authorized', async () => {
+    (vi.mocked(typedGet) as any).mockResolvedValue({
+      Item: {
+        phone: 5555550001,
+        departments: [
+          { id: 'Baca', active: true },
+        ],
+      },
+    });
+    (vi.mocked(typedDeleteItem) as any).mockResolvedValue({});
+
+    const req = generateApiEvent({
+      method: 'DELETE',
+      path: '',
+      pathParameters: {
+        id: '5555550001',
+      },
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('Returns 401 on DELETE without user', async () => {
+    const req = generateApiEvent({
+      method: 'DELETE',
+      path: '',
+      pathParameters: {
+        id: '5555550001',
+      },
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('Returns 403 on DELETE for non-admin', async () => {
+    const req = generateApiEvent({
+      method: 'DELETE',
+      path: '',
+      pathParameters: {
+        id: '5555550001',
+      },
+    });
+    mockUserRequest(req, true, false, false);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/tests/resources/api/v2/userDepartment.test.ts
+++ b/tests/resources/api/v2/userDepartment.test.ts
@@ -1,0 +1,268 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import {
+  generateApiEvent, mockUserRequest, testUserAuth
+} from './_utils';
+
+import { main } from '@/resources/api/v2/userDepartment';
+import {
+  typedGet,
+  typedUpdate
+} from '@/utils/backend/dynamoTyped';
+
+describe('resources/api/v2/userDepartment', () => {
+  it('Returns 400 for invalid params', async () => {
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      body: JSON.stringify({ active: true }),
+    });
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  testUserAuth({
+    method: 'POST',
+    path: '',
+    pathParameters: {
+      id: '5555551111',
+      department: 'Baca',
+    },
+    body: JSON.stringify({ active: true }),
+  }, main, true);
+
+  it('Returns 404 when user not found on POST', async () => {
+    (vi.mocked(typedGet) as any).mockResolvedValue({});
+
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      pathParameters: {
+        id: '5555551111',
+        department: 'Baca',
+      },
+      body: JSON.stringify({
+        active: true,
+      }),
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('Updates user department and queues activation', async () => {
+    (vi.mocked(typedGet) as any).mockResolvedValue({
+      Item: {
+        phone: 5555551111,
+        fName: 'A',
+        lName: 'B',
+        departments: [
+          { id: 'Baca', active: false },
+        ],
+      },
+    });
+    (vi.mocked(typedUpdate) as any).mockResolvedValue({
+      Attributes: {
+        phone: 5555551111,
+        fName: 'A',
+        lName: 'B',
+        departments: [
+          { id: 'Baca', active: true },
+        ],
+      },
+    });
+
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      pathParameters: {
+        id: '5555551111',
+        department: 'Baca',
+      },
+      body: JSON.stringify({
+        active: true,
+      }),
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('Returns 403 for POST when admin lacks target department scope', async () => {
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      pathParameters: {
+        id: '5555551111',
+        department: 'Baca',
+      },
+      body: JSON.stringify({
+        active: true,
+      }),
+    });
+    mockUserRequest(req, true, true, false);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(403);
+  });
+
+  testUserAuth({
+    method: 'PATCH',
+    path: '',
+    pathParameters: {
+      id: '5555551111',
+      department: 'Baca',
+    },
+    body: JSON.stringify({ active: true }),
+  }, main, true);
+
+  it('Updates user department via PATCH', async () => {
+    (vi.mocked(typedGet) as any).mockResolvedValue({
+      Item: {
+        phone: 5555551111,
+        fName: 'A',
+        lName: 'B',
+        departments: [
+          { id: 'Baca', active: true },
+        ],
+      },
+    });
+    (vi.mocked(typedUpdate) as any).mockResolvedValue({
+      Attributes: {
+        phone: 5555551111,
+        fName: 'A',
+        lName: 'B',
+        departments: [
+          { id: 'Baca', active: false },
+        ],
+      },
+    });
+
+    const req = generateApiEvent({
+      method: 'PATCH',
+      path: '',
+      pathParameters: {
+        id: '5555551111',
+        department: 'Baca',
+      },
+      body: JSON.stringify({
+        active: false,
+      }),
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('Returns 403 for PATCH when admin lacks target department scope', async () => {
+    const req = generateApiEvent({
+      method: 'PATCH',
+      path: '',
+      pathParameters: {
+        id: '5555551111',
+        department: 'Baca',
+      },
+      body: JSON.stringify({
+        active: false,
+      }),
+    });
+    mockUserRequest(req, true, true, false);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(403);
+  });
+
+  testUserAuth({
+    method: 'DELETE',
+    path: '',
+    pathParameters: {
+      id: '5555551111',
+      department: 'Baca',
+    },
+  }, main, true);
+
+  it('Deletes department mapping', async () => {
+    (vi.mocked(typedGet) as any).mockResolvedValue({
+      Item: {
+        phone: 5555551111,
+        fName: 'A',
+        lName: 'B',
+        departments: [
+          { id: 'Baca', active: true },
+          { id: 'Other', active: true },
+        ],
+      },
+    });
+    (vi.mocked(typedUpdate) as any).mockResolvedValue({
+      Attributes: {
+        phone: 5555551111,
+        fName: 'A',
+        lName: 'B',
+        departments: [
+          { id: 'Other', active: true },
+        ],
+      },
+    });
+
+    const req = generateApiEvent({
+      method: 'DELETE',
+      path: '',
+      pathParameters: {
+        id: '5555551111',
+        department: 'Baca',
+      },
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('Returns existing user when DELETE target department is missing', async () => {
+    (vi.mocked(typedGet) as any).mockResolvedValue({
+      Item: {
+        phone: 5555551111,
+        fName: 'A',
+        lName: 'B',
+        departments: [
+          { id: 'Other', active: true },
+        ],
+      },
+    });
+
+    const req = generateApiEvent({
+      method: 'DELETE',
+      path: '',
+      pathParameters: {
+        id: '5555551111',
+        department: 'Baca',
+      },
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+    expect(vi.mocked(typedUpdate)).not.toHaveBeenCalled();
+  });
+
+  it('Returns 403 for DELETE when admin lacks target department scope', async () => {
+    const req = generateApiEvent({
+      method: 'DELETE',
+      path: '',
+      pathParameters: {
+        id: '5555551111',
+        department: 'Baca',
+      },
+    });
+    mockUserRequest(req, true, true, false);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/tests/resources/api/v2/users.test.ts
+++ b/tests/resources/api/v2/users.test.ts
@@ -1,0 +1,96 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import {
+  generateApiEvent,
+  mockUserRequest,
+  testUserAuth
+} from './_utils';
+
+import { main } from '@/resources/api/v2/users';
+import {
+  typedPutItem,
+  typedScan
+} from '@/utils/backend/dynamoTyped';
+
+describe('resources/api/v2/users', () => {
+  testUserAuth({
+    method: 'GET',
+    path: '',
+  }, main, true);
+
+  it('Returns user list for admins', async () => {
+    (vi.mocked(typedScan) as any).mockResolvedValue({
+      Items: [
+        {
+          phone: 5555550001,
+          fName: 'A',
+          lName: 'B',
+          departments: [ { id: 'Baca', active: true } ],
+        },
+      ],
+    });
+
+    const req = generateApiEvent({
+      method: 'GET',
+      path: '',
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('Returns 400 for invalid POST body', async () => {
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      body: JSON.stringify({}),
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(400);
+  });
+
+  testUserAuth({
+    method: 'POST',
+    path: '',
+    body: JSON.stringify({
+      phone: 5555550001,
+      fName: 'A',
+      lName: 'B',
+      department: 'Baca',
+      admin: false,
+      callSign: 'B-1',
+      talkgroups: [ 8198 ],
+      getTranscript: false,
+      getTranscriptOnly: true,
+    }),
+  }, main, true);
+
+  it('Creates user and queues activation', async () => {
+    (vi.mocked(typedPutItem) as any).mockResolvedValue({});
+
+    const req = generateApiEvent({
+      method: 'POST',
+      path: '',
+      body: JSON.stringify({
+        phone: 5555550001,
+        fName: 'A',
+        lName: 'B',
+        department: 'Baca',
+        admin: false,
+        callSign: 'B-1',
+        talkgroups: [ 8198 ],
+        getTranscript: true,
+        getTranscriptOnly: true,
+      }),
+    });
+    mockUserRequest(req, true, true, true);
+
+    const res = await main(req);
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/tests/resources/dailyEvents.test.ts
+++ b/tests/resources/dailyEvents.test.ts
@@ -1,0 +1,144 @@
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi
+} from 'vitest';
+
+import { main } from '@/resources/dailyEvents';
+import {
+  typedQuery, typedScan, typedUpdate
+} from '@/utils/backend/dynamoTyped';
+
+const { athenaSendMock } = vi.hoisted(() => ({
+  athenaSendMock: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-athena', () => ({
+  AthenaClient: vi.fn(() => ({
+    send: athenaSendMock,
+  })),
+  StartQueryExecutionCommand: vi.fn(v => ({
+    type: 'startQueryExecution',
+    ...v,
+  })),
+  GetQueryExecutionCommand: vi.fn(v => ({
+    type: 'getQueryExecution',
+    ...v,
+  })),
+  GetQueryResultsCommand: vi.fn(v => ({
+    type: 'getQueryResults',
+    ...v,
+  })),
+}));
+
+describe('resources/dailyEvents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation(((cb: (...args: unknown[]) => unknown) => {
+      cb();
+      return 0 as never;
+    }) as never);
+  });
+
+  it('Exits early when radios are missing', async () => {
+    (vi.mocked(typedScan) as any).mockResolvedValueOnce({});
+
+    await expect(main()).resolves.toBeUndefined();
+  });
+
+  it('Exits early when talkgroups are missing', async () => {
+    (vi.mocked(typedScan) as any)
+      .mockResolvedValueOnce({
+        Items: [ { RadioID: '101' } ],
+      })
+      .mockResolvedValueOnce({});
+
+    await expect(main()).resolves.toBeUndefined();
+  });
+
+  it('Processes device and talkgroup event/recording updates', async () => {
+    (vi.mocked(typedScan) as any)
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            RadioID: '101',
+            InUse: 'Y',
+            Count: 0,
+            EventsCount: 0,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            ID: 8198,
+            InUse: 'Y',
+            Count: 0,
+            EventsCount: 0,
+          },
+        ],
+      });
+
+    (vi.mocked(typedQuery) as any)
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            RadioID: '101',
+            StartTime: 1735689601,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            Talkgroup: 8198,
+            StartTime: 1735689601,
+            Added: 1735689601,
+          },
+        ],
+      });
+
+    athenaSendMock.mockImplementation(async (command: { type: string; QueryExecutionId?: string; QueryString?: string }) => {
+      if (command.type === 'startQueryExecution') {
+        return {
+          QueryExecutionId: command.QueryString?.includes('radioid')
+            ? 'q-radio'
+            : 'q-tg',
+        };
+      }
+      if (command.type === 'getQueryExecution') {
+        return {
+          QueryExecution: {
+            Status: {
+              State: 'SUCCEEDED',
+            },
+          },
+        };
+      }
+      if (command.type === 'getQueryResults' && command.QueryExecutionId === 'q-radio') {
+        return {
+          ResultSet: {
+            Rows: [
+              { Data: [ { VarCharValue: 'radioid' }, { VarCharValue: 'num' } ] },
+              { Data: [ { VarCharValue: '101' }, { VarCharValue: '5' } ] },
+            ],
+          },
+        };
+      }
+
+      return {
+        ResultSet: {
+          Rows: [
+            { Data: [ { VarCharValue: 'talkgroup' }, { VarCharValue: 'num' } ] },
+            { Data: [ { VarCharValue: '8198' }, { VarCharValue: '7' } ] },
+          ],
+        },
+      };
+    });
+
+    await expect(main()).resolves.toBeUndefined();
+    expect(typedUpdate).toHaveBeenCalled();
+  });
+});

--- a/tests/resources/emailHandler.test.ts
+++ b/tests/resources/emailHandler.test.ts
@@ -1,0 +1,121 @@
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi
+} from 'vitest';
+
+import { S3Mock } from '../../__mocks__/@aws-sdk/client-s3';
+
+import { main } from '@/resources/emailHandler';
+
+const {
+  parseMock,
+  sesSendMock,
+} = vi.hoisted(() => ({
+  parseMock: vi.fn(),
+  sesSendMock: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('postal-mime', () => ({
+  default: {
+    parse: parseMock,
+  },
+}));
+
+vi.mock('@aws-sdk/client-sesv2', () => ({
+  SESv2Client: vi.fn(() => ({
+    send: sesSendMock,
+  })),
+  SendEmailCommand: vi.fn(v => v),
+}));
+
+describe('resources/emailHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('Forwards parsed HTML/text email content', async () => {
+    parseMock.mockResolvedValue({
+      from: { address: 'sender@example.com' },
+      subject: 'Test Subject',
+      html: '<p>Hello</p>',
+      text: 'Hello',
+      attachments: [],
+    });
+    S3Mock.setResult('get', {
+      Body: {
+        transformToString: async () => 'From: test@example.com\n\nhello',
+      },
+    });
+
+    await expect(main({
+      Records: [
+        {
+          ses: {
+            mail: {
+              messageId: 'msg-1',
+            },
+          },
+        },
+      ],
+    } as never)).resolves.toBeUndefined();
+
+    expect(sesSendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('Forwards attachments as raw content', async () => {
+    parseMock.mockResolvedValue({
+      from: { address: 'sender@example.com' },
+      subject: 'With Attachment',
+      html: undefined,
+      text: 'Attachment body',
+      attachments: [
+        {
+          filename: 'hello.txt',
+          mimeType: 'text/plain',
+          disposition: 'attachment',
+          contentId: 'cid1',
+          content: 'hello',
+          encoding: 'utf8',
+        },
+      ],
+    });
+    S3Mock.setResult('get', {
+      Body: {
+        transformToString: async () => 'raw-message',
+      },
+    });
+
+    await expect(main({
+      Records: [
+        {
+          ses: {
+            mail: {
+              messageId: 'msg-2',
+            },
+          },
+        },
+      ],
+    } as never)).resolves.toBeUndefined();
+
+    expect(sesSendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('Throws when S3 object body is missing', async () => {
+    S3Mock.setResult('get', {});
+
+    await expect(main({
+      Records: [
+        {
+          ses: {
+            mail: {
+              messageId: 'msg-3',
+            },
+          },
+        },
+      ],
+    } as never)).rejects.toThrow('Email body is undefined');
+  });
+});

--- a/tests/resources/eventFileQueueHandler.test.ts
+++ b/tests/resources/eventFileQueueHandler.test.ts
@@ -1,0 +1,41 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+vi.mock('@aws-sdk/client-glue', () => {
+  const send = vi.fn(input => {
+    if ('PartitionsToGet' in input) {
+      return Promise.resolve({ Partitions: [] });
+    }
+
+    return Promise.resolve({});
+  });
+
+  return {
+    GlueClient: vi.fn(() => ({ send })),
+    BatchGetPartitionCommand: vi.fn(v => v),
+    BatchCreatePartitionCommand: vi.fn(v => v),
+  };
+});
+
+import { main } from '@/resources/eventFileQueueHandler';
+
+describe('resources/eventFileQueueHandler', () => {
+  it('Returns early when no records exist', async () => {
+    await expect(main({ Records: [] } as never)).resolves.toBeUndefined();
+  });
+
+  it('Builds partition requests from S3 keys', async () => {
+    await expect(main({
+      Records: [
+        {
+          s3: {
+            object: {
+              key: 'datetime=2026-01-01-00/event=call/file.orc',
+            },
+          },
+        },
+      ],
+    } as never)).resolves.toBeUndefined();
+  });
+});

--- a/tests/resources/generateInvoices.test.ts
+++ b/tests/resources/generateInvoices.test.ts
@@ -1,0 +1,125 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import { S3Mock } from '../../__mocks__/@aws-sdk/client-s3';
+
+import { main } from '@/resources/generateInvoices';
+import {
+  typedPutItem, typedScan
+} from '@/utils/backend/dynamoTyped';
+import { getTwilioSecret } from '@/deprecated/utils/general';
+
+vi.mock('pdfkit', () => {
+  return {
+    default: class MockPdf {
+      private handlers: { [key: string]: ((...args: unknown[]) => void)[] } = {};
+
+      on(event: string, cb: (...args: unknown[]) => void) {
+        this.handlers[event] = this.handlers[event] || [];
+        this.handlers[event].push(cb);
+        return this;
+      }
+
+      fontSize() {
+        return this;
+      }
+
+      text() {
+        return this;
+      }
+
+      moveDown() {
+        return this;
+      }
+
+      table() {
+        return this;
+      }
+
+      end() {
+        (this.handlers.data || []).forEach(cb => cb(Buffer.from('pdf')));
+        (this.handlers.end || []).forEach(cb => cb());
+      }
+    },
+  };
+});
+
+vi.mock('twilio', () => ({
+  default: vi.fn(() => ({
+    api: {
+      v2010: {
+        account: {
+          usage: {
+            records: {
+              list: vi.fn((_: unknown, cb: (err: unknown, items: Array<{ category: string; price: string; usage: string; usageUnit: string; startDate: string; endDate: string }>) => void) => cb(null, [
+                {
+                  category: 'sms-outbound',
+                  price: '1.25',
+                  usage: '10',
+                  usageUnit: 'messages',
+                  startDate: '2026-01-01',
+                  endDate: '2026-01-31',
+                },
+                {
+                  category: 'totalprice',
+                  price: '1.25',
+                  usage: '0',
+                  usageUnit: 'messages',
+                  startDate: '2026-01-01',
+                  endDate: '2026-01-31',
+                },
+              ])),
+            },
+          },
+        },
+      },
+    },
+  })),
+}));
+
+const { sesSendMock } = vi.hoisted(() => ({
+  sesSendMock: vi.fn().mockResolvedValue({}),
+}));
+vi.mock('@aws-sdk/client-sesv2', () => ({
+  SESv2Client: vi.fn(() => ({
+    send: sesSendMock,
+  })),
+  SendEmailCommand: vi.fn(v => v),
+}));
+
+describe('resources/generateInvoices', () => {
+  it('Exits when there are no departments to invoice', async () => {
+    (vi.mocked(typedScan) as any).mockResolvedValue({});
+
+    await expect(main()).resolves.toBeUndefined();
+  });
+
+  it('Generates and stores invoices for monthly departments', async () => {
+    (vi.mocked(typedScan) as any).mockResolvedValue({
+      Items: [
+        {
+          id: 'Baca',
+          name: 'Baca Fire',
+          invoiceFrequency: 'monthly',
+          invoiceEmail: [ 'billing@example.com' ],
+        },
+      ],
+    });
+    (vi.mocked(getTwilioSecret) as any).mockResolvedValue({
+      accountSidBaca: 'sid',
+      authTokenBaca: 'token',
+    });
+
+    S3Mock.setResult('get', {
+      Body: {
+        transformToByteArray: async () => Uint8Array.from([ 1, 2, 3 ]),
+      },
+    });
+
+    await expect(main()).resolves.toBeUndefined();
+
+    expect(typedPutItem).toHaveBeenCalledTimes(1);
+    expect(sesSendMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/resources/importAladTec.test.ts
+++ b/tests/resources/importAladTec.test.ts
@@ -1,0 +1,54 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import { SecretsManagerClientMock } from '../../__mocks__/@aws-sdk/client-secrets-manager';
+
+import {
+  getAuthCookie,
+  main
+} from '@/resources/importAladTec';
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+describe('resources/importAladTec', () => {
+  it('Extracts auth cookie from login response', async () => {
+    vi.mocked(SecretsManagerClientMock.send).mockResolvedValue({
+      SecretString: JSON.stringify({
+        username: 'user',
+        password: 'pass',
+      }),
+    });
+    fetchMock.mockResolvedValueOnce({
+      headers: {
+        getSetCookie: () => [ 'ems9646s=auth-cookie; Path=/' ],
+      },
+    });
+
+    await expect(getAuthCookie()).resolves.toBe('auth-cookie');
+  });
+
+  it('Runs main without throwing for mocked responses', async () => {
+    vi.mocked(SecretsManagerClientMock.send).mockResolvedValue({
+      SecretString: JSON.stringify({
+        username: 'user',
+        password: 'pass',
+      }),
+    });
+    fetchMock
+      .mockResolvedValueOnce({
+        headers: {
+          getSetCookie: () => [ 'ems9646s=auth-cookie; Path=/' ],
+        },
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({}),
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({ rows: [] }),
+      });
+
+    await expect(main()).resolves.toBeUndefined();
+  });
+});

--- a/tests/resources/queue.test.ts
+++ b/tests/resources/queue.test.ts
@@ -1,0 +1,244 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import { main } from '@/resources/queue';
+import {
+  typedGet,
+  typedQuery,
+  typedScan,
+  typedUpdate
+} from '@/utils/backend/dynamoTyped';
+import {
+  getPageNumber,
+  getUserRecipients,
+  saveMessageData,
+  sendMessage
+} from '@/utils/backend/texts';
+
+vi.mock('@/deprecated/utils/general', () => ({
+  getTwilioSecret: vi.fn(async () => ({
+    accountSid: 'sid',
+    authToken: 'token',
+  })),
+  twilioPhoneCategories: vi.fn(async () => ({
+    pageBaca: {
+      number: '+15550000000',
+    },
+  })),
+  twilioPhoneNumbers: vi.fn(async () => ({
+    '+15550000000': {
+      department: 'Baca',
+      type: 'page',
+    },
+  })),
+}));
+
+vi.mock('@/utils/backend/shiftData', () => ({
+  getShiftData: vi.fn(async () => ({
+    shifts: [],
+    people: {},
+  })),
+  shiftNameMappings: {},
+}));
+
+describe('resources/queue', () => {
+  it('Processes auth-code action messages', async () => {
+    (vi.mocked(typedUpdate) as any).mockResolvedValue({
+      Attributes: {
+        phone: 5555551111,
+        fName: 'A',
+        lName: 'B',
+        departments: [ { id: 'Baca', active: true } ],
+      },
+    });
+    (vi.mocked(getPageNumber) as any).mockResolvedValue('+15555551111');
+    (vi.mocked(sendMessage) as any).mockResolvedValue(undefined);
+
+    await expect(main({
+      Records: [
+        {
+          body: JSON.stringify({
+            action: 'auth-code',
+            phone: 5555551111,
+          }),
+        },
+      ],
+    } as never)).resolves.toBeUndefined();
+  });
+
+  it('Processes site-status updates', async () => {
+    (vi.mocked(typedUpdate) as any).mockResolvedValue({});
+
+    await expect(main({
+      Records: [
+        {
+          body: JSON.stringify({
+            action: 'site-status',
+            sites: {
+              '1-2': {
+                UpdateTime: { TEST: 10 },
+                ConvChannel: { TEST: true },
+              },
+            },
+          }),
+        },
+      ],
+    } as never)).resolves.toBeUndefined();
+
+    expect(typedUpdate).toHaveBeenCalled();
+  });
+
+  it('Processes page action and sends notifications', async () => {
+    (vi.mocked(getUserRecipients) as any).mockResolvedValue([
+      {
+        phone: 5555550001,
+        getTranscriptOnly: false,
+      },
+    ]);
+    (vi.mocked(getPageNumber) as any).mockResolvedValue('+15555550001');
+    (vi.mocked(saveMessageData) as any).mockResolvedValue(undefined);
+    (vi.mocked(sendMessage) as any).mockResolvedValue(undefined);
+    (vi.mocked(typedScan) as any).mockResolvedValue({ Items: [] });
+
+    await expect(main({
+      Records: [
+        {
+          body: JSON.stringify({
+            action: 'page',
+            key: '8198-1735689600',
+            tg: 8198,
+            len: 4,
+            isTest: true,
+          }),
+        },
+      ],
+    } as never)).resolves.toBeUndefined();
+
+    expect(sendMessage).toHaveBeenCalled();
+  });
+
+  it('Processes activate-user messages', async () => {
+    (vi.mocked(typedGet) as any).mockResolvedValue({
+      Item: {
+        phone: 5555550001,
+        fName: 'A',
+        lName: 'B',
+        departments: [ { id: 'Baca', active: true } ],
+        talkgroups: [ 8198 ],
+      },
+    });
+    (vi.mocked(typedScan) as any).mockResolvedValue({
+      Items: [
+        {
+          phone: 5555550002,
+          fName: 'Admin',
+          lName: 'One',
+          departments: [ { id: 'Baca', active: true, admin: true } ],
+        },
+      ],
+    });
+    (vi.mocked(typedQuery) as any).mockResolvedValue({
+      Items: [
+        {
+          Key: 'folder/8198-1735689600',
+          Talkgroup: 8198,
+        },
+      ],
+    });
+    (vi.mocked(getPageNumber) as any).mockResolvedValue('+15555550001');
+    (vi.mocked(saveMessageData) as any).mockResolvedValue(undefined);
+    (vi.mocked(sendMessage) as any).mockResolvedValue(undefined);
+
+    await expect(main({
+      Records: [
+        {
+          body: JSON.stringify({
+            action: 'activate-user',
+            phone: 5555550001,
+            department: 'Baca',
+          }),
+        },
+      ],
+    } as never)).resolves.toBeUndefined();
+
+    expect(sendMessage).toHaveBeenCalled();
+  });
+
+  it('Processes phone-issue alerts', async () => {
+    (vi.mocked(getUserRecipients) as any).mockResolvedValue([
+      {
+        phone: 5555550001,
+        departments: [ { id: 'Baca', active: true, admin: true } ],
+      },
+    ]);
+    (vi.mocked(getPageNumber) as any).mockResolvedValue('+15555550001');
+    (vi.mocked(saveMessageData) as any).mockResolvedValue(undefined);
+    (vi.mocked(sendMessage) as any).mockResolvedValue(undefined);
+
+    await expect(main({
+      Records: [
+        {
+          body: JSON.stringify({
+            action: 'phone-issue',
+            number: 5555550003,
+            name: 'Alert Number',
+            department: [ 'Baca' ],
+            count: 10,
+          }),
+        },
+      ],
+    } as never)).resolves.toBeUndefined();
+
+    expect(sendMessage).toHaveBeenCalled();
+  });
+
+  it('Processes twilio-text announcements for department admins', async () => {
+    (vi.mocked(getUserRecipients) as any).mockResolvedValue([
+      {
+        phone: 5555550001,
+      },
+    ]);
+    (vi.mocked(getPageNumber) as any).mockResolvedValue('+15555550001');
+    (vi.mocked(saveMessageData) as any).mockResolvedValue(undefined);
+    (vi.mocked(sendMessage) as any).mockResolvedValue(undefined);
+
+    await expect(main({
+      Records: [
+        {
+          body: JSON.stringify({
+            action: 'twilio-text',
+            body: {
+              To: '+15550000000',
+              Body: 'Station check-in',
+            },
+            user: {
+              phone: 5555550002,
+              fName: 'Admin',
+              lName: 'User',
+              departments: [
+                { id: 'Baca', active: true, admin: true },
+              ],
+              isTest: true,
+            },
+          }),
+        },
+      ],
+    } as never)).resolves.toBeUndefined();
+
+    expect(saveMessageData).toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalled();
+  });
+
+  it('Throws for unknown actions', async () => {
+    await expect(main({
+      Records: [
+        {
+          body: JSON.stringify({
+            action: 'unknown-action',
+          }),
+        },
+      ],
+    } as never)).rejects.toThrow('Unkown body');
+  });
+});

--- a/tests/resources/queue.test.ts
+++ b/tests/resources/queue.test.ts
@@ -49,21 +49,22 @@ describe('resources/queue', () => {
         phone: 5555551111,
         fName: 'A',
         lName: 'B',
-        departments: [ { id: 'Baca', active: true } ],
+        departments: [ {
+          id: 'Baca',
+          active: true,
+        }, ],
       },
     });
     (vi.mocked(getPageNumber) as any).mockResolvedValue('+15555551111');
     (vi.mocked(sendMessage) as any).mockResolvedValue(undefined);
 
     await expect(main({
-      Records: [
-        {
-          body: JSON.stringify({
-            action: 'auth-code',
-            phone: 5555551111,
-          }),
-        },
-      ],
+      Records: [ {
+        body: JSON.stringify({
+          action: 'auth-code',
+          phone: 5555551111,
+        }),
+      }, ],
     } as never)).resolves.toBeUndefined();
   });
 
@@ -71,48 +72,42 @@ describe('resources/queue', () => {
     (vi.mocked(typedUpdate) as any).mockResolvedValue({});
 
     await expect(main({
-      Records: [
-        {
-          body: JSON.stringify({
-            action: 'site-status',
-            sites: {
-              '1-2': {
-                UpdateTime: { TEST: 10 },
-                ConvChannel: { TEST: true },
-              },
+      Records: [ {
+        body: JSON.stringify({
+          action: 'site-status',
+          sites: {
+            '1-2': {
+              UpdateTime: { TEST: 10, },
+              ConvChannel: { TEST: true, },
             },
-          }),
-        },
-      ],
+          },
+        }),
+      }, ],
     } as never)).resolves.toBeUndefined();
 
     expect(typedUpdate).toHaveBeenCalled();
   });
 
   it('Processes page action and sends notifications', async () => {
-    (vi.mocked(getUserRecipients) as any).mockResolvedValue([
-      {
-        phone: 5555550001,
-        getTranscriptOnly: false,
-      },
-    ]);
+    (vi.mocked(getUserRecipients) as any).mockResolvedValue([ {
+      phone: 5555550001,
+      getTranscriptOnly: false,
+    }, ]);
     (vi.mocked(getPageNumber) as any).mockResolvedValue('+15555550001');
     (vi.mocked(saveMessageData) as any).mockResolvedValue(undefined);
     (vi.mocked(sendMessage) as any).mockResolvedValue(undefined);
-    (vi.mocked(typedScan) as any).mockResolvedValue({ Items: [] });
+    (vi.mocked(typedScan) as any).mockResolvedValue({ Items: [], });
 
     await expect(main({
-      Records: [
-        {
-          body: JSON.stringify({
-            action: 'page',
-            key: '8198-1735689600',
-            tg: 8198,
-            len: 4,
-            isTest: true,
-          }),
-        },
-      ],
+      Records: [ {
+        body: JSON.stringify({
+          action: 'page',
+          key: '8198-1735689600',
+          tg: 8198,
+          len: 4,
+          isTest: true,
+        }),
+      }, ],
     } as never)).resolves.toBeUndefined();
 
     expect(sendMessage).toHaveBeenCalled();
@@ -124,106 +119,105 @@ describe('resources/queue', () => {
         phone: 5555550001,
         fName: 'A',
         lName: 'B',
-        departments: [ { id: 'Baca', active: true } ],
-        talkgroups: [ 8198 ],
+        departments: [ {
+          id: 'Baca',
+          active: true,
+        }, ],
+        talkgroups: [ 8198, ],
       },
     });
     (vi.mocked(typedScan) as any).mockResolvedValue({
-      Items: [
-        {
-          phone: 5555550002,
-          fName: 'Admin',
-          lName: 'One',
-          departments: [ { id: 'Baca', active: true, admin: true } ],
-        },
-      ],
+      Items: [ {
+        phone: 5555550002,
+        fName: 'Admin',
+        lName: 'One',
+        departments: [ {
+          id: 'Baca',
+          active: true,
+          admin: true,
+        }, ],
+      }, ],
     });
     (vi.mocked(typedQuery) as any).mockResolvedValue({
-      Items: [
-        {
-          Key: 'folder/8198-1735689600',
-          Talkgroup: 8198,
-        },
-      ],
+      Items: [ {
+        Key: 'folder/8198-1735689600',
+        Talkgroup: 8198,
+      }, ],
     });
     (vi.mocked(getPageNumber) as any).mockResolvedValue('+15555550001');
     (vi.mocked(saveMessageData) as any).mockResolvedValue(undefined);
     (vi.mocked(sendMessage) as any).mockResolvedValue(undefined);
 
     await expect(main({
-      Records: [
-        {
-          body: JSON.stringify({
-            action: 'activate-user',
-            phone: 5555550001,
-            department: 'Baca',
-          }),
-        },
-      ],
+      Records: [ {
+        body: JSON.stringify({
+          action: 'activate-user',
+          phone: 5555550001,
+          department: 'Baca',
+        }),
+      }, ],
     } as never)).resolves.toBeUndefined();
 
     expect(sendMessage).toHaveBeenCalled();
   });
 
   it('Processes phone-issue alerts', async () => {
-    (vi.mocked(getUserRecipients) as any).mockResolvedValue([
-      {
-        phone: 5555550001,
-        departments: [ { id: 'Baca', active: true, admin: true } ],
-      },
-    ]);
+    (vi.mocked(getUserRecipients) as any).mockResolvedValue([ {
+      phone: 5555550001,
+      departments: [ {
+        id: 'Baca',
+        active: true,
+        admin: true,
+      }, ],
+    }, ]);
     (vi.mocked(getPageNumber) as any).mockResolvedValue('+15555550001');
     (vi.mocked(saveMessageData) as any).mockResolvedValue(undefined);
     (vi.mocked(sendMessage) as any).mockResolvedValue(undefined);
 
     await expect(main({
-      Records: [
-        {
-          body: JSON.stringify({
-            action: 'phone-issue',
-            number: 5555550003,
-            name: 'Alert Number',
-            department: [ 'Baca' ],
-            count: 10,
-          }),
-        },
-      ],
+      Records: [ {
+        body: JSON.stringify({
+          action: 'phone-issue',
+          number: 5555550003,
+          name: 'Alert Number',
+          department: [ 'Baca', ],
+          count: 10,
+        }),
+      }, ],
     } as never)).resolves.toBeUndefined();
 
     expect(sendMessage).toHaveBeenCalled();
   });
 
   it('Processes twilio-text announcements for department admins', async () => {
-    (vi.mocked(getUserRecipients) as any).mockResolvedValue([
-      {
-        phone: 5555550001,
-      },
-    ]);
+    (vi.mocked(getUserRecipients) as any).mockResolvedValue([ {
+      phone: 5555550001,
+    }, ]);
     (vi.mocked(getPageNumber) as any).mockResolvedValue('+15555550001');
     (vi.mocked(saveMessageData) as any).mockResolvedValue(undefined);
     (vi.mocked(sendMessage) as any).mockResolvedValue(undefined);
 
     await expect(main({
-      Records: [
-        {
-          body: JSON.stringify({
-            action: 'twilio-text',
-            body: {
-              To: '+15550000000',
-              Body: 'Station check-in',
-            },
-            user: {
-              phone: 5555550002,
-              fName: 'Admin',
-              lName: 'User',
-              departments: [
-                { id: 'Baca', active: true, admin: true },
-              ],
-              isTest: true,
-            },
-          }),
-        },
-      ],
+      Records: [ {
+        body: JSON.stringify({
+          action: 'twilio-text',
+          body: {
+            To: '+15550000000',
+            Body: 'Station check-in',
+          },
+          user: {
+            phone: 5555550002,
+            fName: 'Admin',
+            lName: 'User',
+            departments: [ {
+              id: 'Baca',
+              active: true,
+              admin: true,
+            }, ],
+            isTest: true,
+          },
+        }),
+      }, ],
     } as never)).resolves.toBeUndefined();
 
     expect(saveMessageData).toHaveBeenCalled();
@@ -232,13 +226,11 @@ describe('resources/queue', () => {
 
   it('Throws for unknown actions', async () => {
     await expect(main({
-      Records: [
-        {
-          body: JSON.stringify({
-            action: 'unknown-action',
-          }),
-        },
-      ],
-    } as never)).rejects.toThrow('Unkown body');
+      Records: [ {
+        body: JSON.stringify({
+          action: 'unknown-action',
+        }),
+      }, ],
+    } as never)).rejects.toThrow('Unknown body');
   });
 });

--- a/tests/resources/s3.test.ts
+++ b/tests/resources/s3.test.ts
@@ -701,7 +701,7 @@ describe('resources/s3', () => {
 
       S3Mock.setResult('head', createDtrPageHeadInfo);
 
-      vi.mocked(typedQuery).mockResolvedValue({
+      (vi.mocked(typedQuery) as any).mockResolvedValue({
         Items: [
           createDtrItem,
           getFileItem(
@@ -755,7 +755,7 @@ describe('resources/s3', () => {
 
       S3Mock.setResult('head', createDtrPageHeadInfo);
 
-      vi.mocked(typedQuery).mockResolvedValue({
+      (vi.mocked(typedQuery) as any).mockResolvedValue({
         Items: [
           createDtrItem,
           getFileItem(
@@ -811,7 +811,7 @@ describe('resources/s3', () => {
 
       S3Mock.setResult('head', createDtrPageHeadInfo);
 
-      vi.mocked(typedQuery).mockResolvedValue({
+      (vi.mocked(typedQuery) as any).mockResolvedValue({
         Items: [
           createDtrItem,
           getFileItem(
@@ -864,7 +864,7 @@ describe('resources/s3', () => {
 
       S3Mock.setResult('head', createDtrPageHeadInfo);
 
-      vi.mocked(typedQuery).mockResolvedValue({
+      (vi.mocked(typedQuery) as any).mockResolvedValue({
         Items: [
           createDtrItem,
           getFileItem(

--- a/tests/resources/status.test.ts
+++ b/tests/resources/status.test.ts
@@ -1,0 +1,39 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import { main } from '@/resources/status';
+import {
+  typedScan,
+  typedUpdate
+} from '@/utils/backend/dynamoTyped';
+import { sendAlertMessage } from '@/utils/backend/texts';
+
+describe('resources/status', () => {
+  it('Sends alert and updates heartbeat failure state', async () => {
+    vi.useFakeTimers().setSystemTime(600000);
+    (vi.mocked(typedScan) as any).mockResolvedValue({
+      Items: [
+        {
+          Server: 'primary-1',
+          IsPrimary: true,
+          IsFailed: false,
+          LastHeartbeat: 0,
+        },
+        {
+          Server: 'secondary-1',
+          IsPrimary: false,
+          IsFailed: false,
+          LastHeartbeat: 600000,
+        },
+      ],
+    });
+    (vi.mocked(typedUpdate) as any).mockResolvedValue({});
+    vi.mocked(sendAlertMessage).mockResolvedValue();
+
+    await main();
+
+    expect(typedUpdate).toHaveBeenCalled();
+    expect(sendAlertMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/resources/twilioQueueHandler.test.ts
+++ b/tests/resources/twilioQueueHandler.test.ts
@@ -1,0 +1,35 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+import { main } from '@/resources/twilioQueueHandler';
+import { typedUpdate } from '@/utils/backend/dynamoTyped';
+
+describe('resources/twilioQueueHandler', () => {
+  it('Groups statuses by message id and updates dynamo', async () => {
+    (vi.mocked(typedUpdate) as any).mockResolvedValue({});
+
+    await main({
+      Records: [
+        {
+          body: JSON.stringify({
+            datetime: 111,
+            status: 'delivered',
+            eventTime: 1000,
+            phone: '+15555550001',
+          }),
+        },
+        {
+          body: JSON.stringify({
+            datetime: 111,
+            status: 'failed',
+            eventTime: 1010,
+            phone: '+15555550002',
+          }),
+        },
+      ],
+    } as never);
+
+    expect(typedUpdate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/resources/weather.test.ts
+++ b/tests/resources/weather.test.ts
@@ -1,0 +1,41 @@
+import {
+  describe, expect, it, vi
+} from 'vitest';
+
+vi.mock('node-fetch', () => ({
+  default: vi.fn(),
+}));
+
+import fetch from 'node-fetch';
+
+import { PutObjectCommand } from '../../__mocks__/@aws-sdk/client-s3';
+
+import { main } from '@/resources/weather';
+
+describe('resources/weather', () => {
+  it('Fetches data sources and uploads weather json', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce({
+        json: async () => ({ features: [] }),
+      } as any)
+      .mockResolvedValueOnce({
+        json: async () => ({ features: [] }),
+      } as any)
+      .mockResolvedValueOnce({
+        json: async () => ({ features: [] }),
+      } as any)
+      .mockResolvedValueOnce({
+        text: async () => '<table><td><center><strong>A 1</strong></center></td></table>',
+      } as any)
+      .mockResolvedValueOnce({
+        json: async () => ({ features: [] }),
+      } as any)
+      .mockResolvedValueOnce({
+        text: async () => '<script>var _pageData = "[1,6,0,12,0,13,0]";</script>',
+      } as any);
+
+    await expect(main()).resolves.toBeUndefined();
+    expect(PutObjectCommand).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- expand auth coverage across API handlers and method aliases
- add branch-focused tests for API and backend resource handlers
- strengthen login, heartbeats, events, metrics, texts, invoice item, and user-department edge cases

## Validation
- npm run type-check
- npm run build
- npm run test
- npm run synth
- npm run diff
- npm run lint
- npm run document