### PR TITLE
Harden auth cookie handling and bootstrap auth from current-user API

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -87,15 +87,24 @@ function useUser(addAlert: (type: Variant, message: string) => void): [
         },
       });
 
+      if (code === 401) {
+        localStorage.removeItem(localStorageUserKey);
+        setUser({
+          fromApi: true,
+          isFinal: true,
+          isUser: false,
+          isAdmin: false,
+          isDistrictAdmin: false,
+        });
+        return;
+      }
+
       if (
         code !== 200 ||
         apiResult === null ||
         'message' in apiResult
       ) {
-        throw {
-          code,
-          apiResult,
-        };
+        throw new Error(`Unexpected auth bootstrap response: ${code}`);
       }
 
       localStorage.setItem(localStorageUserKey, JSON.stringify(apiResult));
@@ -110,6 +119,21 @@ function useUser(addAlert: (type: Variant, message: string) => void): [
     } catch (e) {
       addAlert('danger', 'Failed to update the current user\'s information');
       logger.error('Failed to fetch current user', e);
+
+      // End loading state on API failures that are not auth-related.
+      setUser(cur => {
+        if (cur && cur.isFinal) {
+          return cur;
+        }
+
+        return {
+          fromApi: true,
+          isFinal: true,
+          isUser: false,
+          isAdmin: false,
+          isDistrictAdmin: false,
+        };
+      });
     }
   }
 
@@ -118,40 +142,7 @@ function useUser(addAlert: (type: Variant, message: string) => void): [
       return;
     }
 
-    // Parse information out of the cookies
-    const cookies: {
-      [key: string]: string | null;
-    } = {};
-    document.cookie.split('; ').forEach(cookie => {
-      const eqSign = cookie.indexOf('=');
-      if (eqSign === -1) {
-        cookies[cookie] = null;
-        return;
-      }
-
-      cookies[cookie.slice(0, eqSign)] = decodeURIComponent(cookie.slice(eqSign + 1));
-    });
-
-    // Check the cookies for an active user
-    if (
-      !cookies['cofrn-token'] ||
-      !cookies['cofrn-user']
-    ) {
-      localStorage.removeItem(localStorageUserKey);
-      setUser({
-        fromApi: false,
-        isFinal: true,
-        isUser: false,
-        isAdmin: false,
-        isDistrictAdmin: false,
-      });
-      return;
-    }
-
-    // Start the process of fetching the user info from the API
-    getUserFromApi();
-
-    // Check localStorage for a user
+    // Seed from localStorage for a faster optimistic render while API auth is verified.
     const lsUserStr = localStorage.getItem(localStorageUserKey);
     if (lsUserStr === null) {
       setUser({
@@ -161,6 +152,7 @@ function useUser(addAlert: (type: Variant, message: string) => void): [
         isAdmin: false,
         isDistrictAdmin: false,
       });
+      getUserFromApi();
       return;
     }
 
@@ -175,10 +167,21 @@ function useUser(addAlert: (type: Variant, message: string) => void): [
         isAdmin: initUser.departments?.some(dep => dep.active && dep.admin) ?? false,
         ...initUser,
       });
+
+      getUserFromApi();
     } catch (e) {
       addAlert('danger', 'Invalid user information was found, attempting to refresh the user');
       logger.error('Failed to parse localStorage user', e);
       localStorage.removeItem(localStorageUserKey);
+
+      setUser({
+        fromApi: false,
+        isFinal: false,
+        isUser: false,
+        isAdmin: false,
+        isDistrictAdmin: false,
+      });
+      getUserFromApi();
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/resources/api/v2/_utils.ts
+++ b/src/resources/api/v2/_utils.ts
@@ -214,15 +214,45 @@ export function getFrontendUserObj(
   return newUser;
 }
 
-const authUserCookie = 'cofrn-user';
 const authTokenCookie = 'cofrn-token';
+
+type SameSiteValue = 'Strict' | 'Lax' | 'None';
+
+interface SetCookieOptions {
+  httpOnly?: boolean;
+  secure?: boolean;
+  sameSite?: SameSiteValue;
+}
 
 export function getDeleteCookieHeader(cookie: string) {
   return `${encodeURIComponent(cookie)}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT`;
 }
 
-export function getSetCookieHeader(cookie: string, value: string, age: number) {
-  return `${encodeURIComponent(cookie)}=${encodeURIComponent(value)}; Secure; SameSite=None; Path=/; Max-Age=${age}`;
+export function getSetCookieHeader(
+  cookie: string,
+  value: string,
+  age: number,
+  {
+    httpOnly = false,
+    secure = true,
+    sameSite = 'Lax',
+  }: SetCookieOptions = {}
+) {
+  const cookieParts = [
+    `${encodeURIComponent(cookie)}=${encodeURIComponent(value)}`,
+    'Path=/',
+    `Max-Age=${age}`,
+    `SameSite=${sameSite}`,
+  ];
+
+  if (secure) {
+    cookieParts.push('Secure');
+  }
+  if (httpOnly) {
+    cookieParts.push('HttpOnly');
+  }
+
+  return cookieParts.join('; ');
 }
 
 export async function getCurrentUser(event: APIGatewayProxyEvent): Promise<[
@@ -258,10 +288,7 @@ export async function getCurrentUser(event: APIGatewayProxyEvent): Promise<[
     }
 
     // Check for the authentication cookies
-    if (
-      !(authUserCookie in cookies) ||
-      !(authTokenCookie in cookies)
-    ) {
+    if (!(authTokenCookie in cookies)) {
       return response;
     }
 
@@ -293,7 +320,7 @@ export async function getCurrentUser(event: APIGatewayProxyEvent): Promise<[
       },
     });
     if (!user.Item) {
-      logger.warn('getCurrentUser', 'failed', `Invalid user from cookie - ${cookies[authUserCookie]}`);
+      logger.warn('getCurrentUser', 'failed', `Invalid user from token payload - ${userPayload.phone}`);
       return response;
     }
 

--- a/src/resources/api/v2/login.ts
+++ b/src/resources/api/v2/login.ts
@@ -219,7 +219,9 @@ const POST: LambdaApiFunction<SubmitLoginCodeApi> = async function (event, user)
     {
       'Set-Cookie': [
         getSetCookieHeader('cofrn-user', params.id.toString(), loginDuration),
-        getSetCookieHeader('cofrn-token', token, loginDuration),
+        getSetCookieHeader('cofrn-token', token, loginDuration, {
+          httpOnly: true,
+        }),
       ],
     },
   ];

--- a/src/resources/api/v2/logout.ts
+++ b/src/resources/api/v2/logout.ts
@@ -45,10 +45,14 @@ const GET: LambdaApiFunction<LogoutApi> = async function (event) {
 
   // Find the cookies to delete
   const cookies = getCookies(event);
-  const setCookieHeaders: string[] = [];
+  const cookiesToDelete = new Set<string>([
+    'cofrn-user',
+    'cofrn-token',
+  ]);
   Object.keys(cookies)
     .filter(key => key.includes('cvfd') || key.includes('cofrn'))
-    .forEach(key => setCookieHeaders.push(getDeleteCookieHeader(key)));
+    .forEach(key => cookiesToDelete.add(key));
+  const setCookieHeaders = Array.from(cookiesToDelete).map(getDeleteCookieHeader);
 
   // Return the response
   return [

--- a/tests/resources/api/v2/_base.test.ts
+++ b/tests/resources/api/v2/_base.test.ts
@@ -369,12 +369,19 @@ describe('resources/api/v2/_base', () => {
   describe('getSetCookieHeader', () => {
     it('Returns a cookie string that will result in the cookie being set', () => {
       expect(getSetCookieHeader('test-cookie', 'test-value', 20))
-        .toEqual('test-cookie=test-value; Secure; SameSite=None; Path=/; Max-Age=20');
+        .toEqual('test-cookie=test-value; Path=/; Max-Age=20; SameSite=Lax; Secure');
     });
 
     it('Encodes the cookie name and value in a URL safe manner', () => {
       expect(getSetCookieHeader('test cookie', 'test;value', 20))
-        .toEqual('test%20cookie=test%3Bvalue; Secure; SameSite=None; Path=/; Max-Age=20');
+        .toEqual('test%20cookie=test%3Bvalue; Path=/; Max-Age=20; SameSite=Lax; Secure');
+    });
+
+    it('Supports secure HttpOnly cookies when requested', () => {
+      expect(getSetCookieHeader('auth', 'token', 30, {
+        httpOnly: true,
+      }))
+        .toEqual('auth=token; Path=/; Max-Age=30; SameSite=Lax; Secure; HttpOnly');
     });
   });
 
@@ -485,9 +492,21 @@ describe('resources/api/v2/_base', () => {
       expect(headers).toEqual({});
     });
 
-    it('Deletes cookies if the cofrn-user cookie is not present', async () => {
+    it('Authenticates with token cookie even if the cofrn-user cookie is not present', async () => {
       // JWT library mock
-      verify.mockReturnValue('none');
+      verify.mockReturnValue({
+        phone: 5555555555,
+      });
+
+      // User perms
+      vi.mocked(getUserPermissions).mockReturnValue({
+        isUser: true,
+        isAdmin: false,
+        isDistrictAdmin: false,
+        activeDepartments: [ 'Baca', ],
+        adminDepartments: [],
+        canEditNames: false,
+      });
 
       // DynamoDB get
       DynamoDBDocumentClientMock.setResult('get', {
@@ -515,35 +534,54 @@ describe('resources/api/v2/_base', () => {
         headers,
       ] = await getCurrentUser(req);
 
-      // Validate that no steps were taken
-      expect(GetSecretValueCommand).toHaveBeenCalledTimes(0);
-      expect(verify).toHaveBeenCalledTimes(0);
-      expect(GetCommand).toHaveBeenCalledTimes(0);
+      // Validate authentication steps were taken
+      expect(GetSecretValueCommand).toHaveBeenCalledTimes(1);
+      expect(GetSecretValueCommand).toHaveBeenCalledWith({
+        SecretId: 'JWT_SECRET_VAL',
+      });
+      expect(verify).toHaveBeenCalledTimes(1);
+      expect(verify).toHaveBeenCalledWith(
+        '1234567890',
+        'JWT-Secret-Value'
+      );
+      expect(GetCommand).toHaveBeenCalledTimes(1);
+      expect(GetCommand).toHaveBeenCalledWith({
+        TableName: 'TABLE_USER_VAL',
+        Key: {
+          phone: 5555555555,
+        },
+      });
 
       // Validate the perms were acquired correctly
-      expect(getUserPermissions).toHaveBeenCalledTimes(1);
+      expect(getUserPermissions).toHaveBeenCalledTimes(2);
       expect(getUserPermissions).toHaveBeenCalledWith(null);
+      expect(getUserPermissions).toHaveBeenCalledWith({
+        phone: 5555555555,
+        Baca: {
+          active: true,
+        },
+      });
 
       // Validate the response - front end user object
-      expect(user).toEqual(null);
+      expect(user).toEqual({
+        phone: 5555555555,
+        Baca: {
+          active: true,
+        },
+      });
 
       // Validate the response - permissions
       expect(perms).toEqual({
-        isUser: false,
+        isUser: true,
         isAdmin: false,
         isDistrictAdmin: false,
-        activeDepartments: [],
+        activeDepartments: [ 'Baca', ],
         adminDepartments: [],
         canEditNames: false,
       });
 
       // Validate the response - headers
-      expect(headers).toEqual({
-        'Set-Cookie': [
-          'cofrn-other=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
-          'cofrn-token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
-        ],
-      });
+      expect(headers).toEqual({});
     });
 
     it('Deletes cookies if the cofrn-token cookie is not present', async () => {

--- a/tests/resources/api/v2/login.test.ts
+++ b/tests/resources/api/v2/login.test.ts
@@ -269,7 +269,13 @@ describe('resources/api/v2/login', () => {
       expect(res.statusCode).toBe(200);
       expect(res.multiValueHeaders?.['Set-Cookie']?.length).toBe(2);
       expect(res.multiValueHeaders?.['Set-Cookie']?.[0]).toContain('cofrn-user=5555551111');
+      expect(res.multiValueHeaders?.['Set-Cookie']?.[0]).toContain('Secure');
+      expect(res.multiValueHeaders?.['Set-Cookie']?.[0]).toContain('SameSite=Lax');
+      expect(res.multiValueHeaders?.['Set-Cookie']?.[0]).not.toContain('HttpOnly');
       expect(res.multiValueHeaders?.['Set-Cookie']?.[1]).toContain('cofrn-token=jwt-token');
+      expect(res.multiValueHeaders?.['Set-Cookie']?.[1]).toContain('Secure');
+      expect(res.multiValueHeaders?.['Set-Cookie']?.[1]).toContain('SameSite=Lax');
+      expect(res.multiValueHeaders?.['Set-Cookie']?.[1]).toContain('HttpOnly');
     });
   });
 });

--- a/tests/resources/api/v2/logout.test.ts
+++ b/tests/resources/api/v2/logout.test.ts
@@ -32,6 +32,9 @@ describe('resources/api/v2/logout', () => {
     const res = await main(req);
     expect(res.statusCode).toBe(302);
     expect(res.multiValueHeaders?.Location).toEqual([ '/login', ]);
-    expect((res.multiValueHeaders?.['Set-Cookie'] || []).length).toBeGreaterThanOrEqual(1);
+    const setCookies = (res.multiValueHeaders?.['Set-Cookie'] || [])
+      .filter((value): value is string => typeof value === 'string');
+    expect(setCookies.some(v => v.startsWith('cofrn-user='))).toBe(true);
+    expect(setCookies.some(v => v.startsWith('cofrn-token='))).toBe(true);
   });
 });


### PR DESCRIPTION
## What changed
- Hardened auth cookie generation in [src/resources/api/v2/_utils.ts](src/resources/api/v2/_utils.ts):
  - Added cookie options with secure defaults (`Secure`, `SameSite=Lax`)
  - Added optional `HttpOnly` support
  - Made token cookie (`cofrn-token`) the required auth credential for server-side user resolution (user hint cookie is now optional)
- Updated login cookie issuance in [src/resources/api/v2/login.ts](src/resources/api/v2/login.ts):
  - `cofrn-token` is now issued with `HttpOnly`
  - `cofrn-user` remains a non-sensitive hint cookie
- Updated logout in [src/resources/api/v2/logout.ts](src/resources/api/v2/logout.ts):
  - Always clears core auth cookies (`cofrn-user`, `cofrn-token`)
  - Also clears matching existing auth-prefix cookies (`cofrn*`, `cvfd*`)
- Updated frontend auth bootstrap in [src/app/layout.tsx](src/app/layout.tsx):
  - Removed JS cookie parsing for trust decisions
  - Auth state now resolves via `GET /api/v2/users/current`
  - Uses localStorage only as optimistic cache while API validation runs
- Expanded tests:
  - [tests/resources/api/v2/login.test.ts](tests/resources/api/v2/login.test.ts) asserts `Secure`, `SameSite=Lax`, and `HttpOnly` on token cookie
  - [tests/resources/api/v2/_base.test.ts](tests/resources/api/v2/_base.test.ts) validates token-only auth and new cookie helper defaults
  - [tests/resources/api/v2/logout.test.ts](tests/resources/api/v2/logout.test.ts) validates both auth cookies are cleared

## Why
This hardens session handling against token exposure to XSS by removing frontend dependence on JS-readable auth token cookies and ensuring stricter cookie attributes.

## Validation performed
- `npm run lint`
- `npm run type-check`
- `npm run test -- tests/resources/api/v2/login.test.ts tests/resources/api/v2/logout.test.ts tests/resources/api/v2/_base.test.ts`
- `npm run test`
- `npm run build`
- `npm run document`

## Risks / follow-ups
- Manual browser validation for `document.cookie` token visibility remains recommended (not executed here).
- CSRF middleware verification item: no dedicated CSRF middleware/test target was found in current backend API paths; this PR keeps scope to cookie hardening and auth bootstrap behavior.

## Notes
- `docs/` changes present in the working tree were intentionally not committed per request.